### PR TITLE
Fix permutation configuration in Permutation Circuit

### DIFF
--- a/zkmemory/src/constraints/consistency_check_circuit.rs
+++ b/zkmemory/src/constraints/consistency_check_circuit.rs
@@ -34,12 +34,7 @@ pub(crate) struct ConsistencyConfig<F: Field + PrimeField> {
 impl<F: Field + PrimeField> ConsistencyConfig<F> {
     fn configure(
         meta: &mut ConstraintSystem<F>,
-        shuffle_input: (
-            Column<Advice>,
-            Column<Fixed>,
-            Column<Advice>,
-            Column<Advice>,
-        ),
+        shuffle_input: (Column<Fixed>, Column<Advice>),
         original_trace_record: TraceRecordWitnessTable<F>,
         sorted_trace_record: TraceRecordWitnessTable<F>,
         lookup_tables: LookUpTables,
@@ -59,13 +54,7 @@ impl<F: Field + PrimeField> ConsistencyConfig<F> {
                 lookup_tables,
                 alpha_power,
             ),
-            permutation_config: ShuffleChip::<F>::configure(
-                meta,
-                shuffle_input.0,
-                shuffle_input.1,
-                shuffle_input.2,
-                shuffle_input.3,
-            ),
+            permutation_config: ShuffleChip::<F>::configure(meta, shuffle_input.0, shuffle_input.1),
             _marker: PhantomData,
         }
     }
@@ -74,10 +63,12 @@ impl<F: Field + PrimeField> ConsistencyConfig<F> {
 /// Define the memory consistency circuit
 #[derive(Default, Clone, Debug)]
 pub(crate) struct MemoryConsistencyCircuit<F: Field + PrimeField + From<B256>> {
-    /// input_trace: Array of trace records before sorting (sorted by time_log) along with its indexes
-    pub(crate) input: Vec<(F, TraceRecord<B256, B256, 32, 32>)>,
+    /// input_trace: Array of trace records before sorting (sorted by time_log)
+    pub(crate) input: Vec<TraceRecord<B256, B256, 32, 32>>,
     /// shuffle_trace: Array after permutations (sorted by address and time_log)
-    pub(crate) shuffle: Vec<(F, TraceRecord<B256, B256, 32, 32>)>,
+    pub(crate) shuffle: Vec<TraceRecord<B256, B256, 32, 32>>,
+    /// A marker since these fields do not use trait F
+    marker: PhantomData<F>,
 }
 
 /// Implement the circuit extension for memory consistency circuit
@@ -93,11 +84,11 @@ impl<F: Field + PrimeField + From<B256>> CircuitExtension<F> for MemoryConsisten
         );
         permutation_circuit.synthesize_with_layouter(config.permutation_config, layouter)?;
         let mut sorted_trace_record = vec![];
-        for (_, trace) in self.shuffle.clone() {
+        for trace in self.shuffle.clone() {
             sorted_trace_record.push(ConvertedTraceRecord::<F>::from(trace));
         }
         let mut original_trace_record = vec![];
-        for (_, trace) in self.input.clone() {
+        for trace in self.input.clone() {
             original_trace_record.push(ConvertedTraceRecord::<F>::from(trace));
         }
         let original_memory_circuit = OriginalMemoryCircuit {
@@ -145,13 +136,11 @@ impl<F: Field + PrimeField + From<B256>> Circuit<F> for MemoryConsistencyCircuit
             tmp = tmp * alpha.clone();
             alpha_power.push(tmp.clone());
         }
-        let input_idx = meta.advice_column();
         let input = meta.fixed_column();
-        let shuffle_idx = meta.advice_column();
         let shuffle = meta.advice_column();
         Self::Config::configure(
             meta,
-            (input_idx, input, shuffle_idx, shuffle),
+            (input, shuffle),
             original_trace_record,
             sorted_trace_record,
             lookup_tables,

--- a/zkmemory/src/constraints/consistency_check_circuit.rs
+++ b/zkmemory/src/constraints/consistency_check_circuit.rs
@@ -68,7 +68,7 @@ pub(crate) struct MemoryConsistencyCircuit<F: Field + PrimeField + From<B256>> {
     /// shuffle_trace: Array after permutations (sorted by address and time_log)
     pub(crate) shuffle: Vec<TraceRecord<B256, B256, 32, 32>>,
     /// A marker since these fields do not use trait F
-    marker: PhantomData<F>,
+    pub(crate) marker: PhantomData<F>,
 }
 
 /// Implement the circuit extension for memory consistency circuit

--- a/zkmemory/src/constraints/helper.rs
+++ b/zkmemory/src/constraints/helper.rs
@@ -1,64 +1,43 @@
+use core::marker::PhantomData;
+
 use crate::{
     base::{Base, B256},
-    constraints::{
-        consistency_check_circuit::MemoryConsistencyCircuit, permutation_circuit::successive_powers,
-    },
+    constraints::consistency_check_circuit::MemoryConsistencyCircuit,
     machine::{AbstractTraceRecord, TraceRecord},
 };
 extern crate alloc;
 use alloc::{vec, vec::Vec};
-use ff::{Field, PrimeField};
 use halo2_proofs::dev::MockProver;
 use halo2curves::pasta::Fp;
 
 // Sort the trace by address -> time_log as keys
-fn sort_trace<K, V, const S: usize, const T: usize, F>(
-    trace: Vec<(F, TraceRecord<K, V, S, T>)>,
-) -> Vec<(F, TraceRecord<K, V, S, T>)>
+fn sort_trace<K, V, const S: usize, const T: usize>(
+    trace: Vec<TraceRecord<K, V, S, T>>,
+) -> Vec<TraceRecord<K, V, S, T>>
 where
     K: Base<S>,
     V: Base<T>,
-    F: Field + PrimeField,
 {
     let mut buffer = trace;
     buffer.sort_by(|a, b| {
-        if a.1.address() == b.1.address() {
-            a.1.time_log().cmp(&b.1.time_log())
+        if a.address() == b.address() {
+            a.time_log().cmp(&b.time_log())
         } else {
-            a.1.address().cmp(&b.1.address())
+            a.address().cmp(&b.address())
         }
     });
     buffer
 }
 
-// Outputs the trace with their respective indexes
-fn trace_with_index<
-    K: Base<S>,
-    V: Base<T>,
-    const S: usize,
-    const T: usize,
-    F: Field + PrimeField,
->(
-    trace: Vec<TraceRecord<K, V, S, T>>,
-) -> Vec<(F, TraceRecord<K, V, S, T>)> {
-    let indexes = successive_powers::<F>(trace.len() as u64);
-    indexes
-        .into_iter()
-        .zip(trace)
-        .collect::<Vec<(F, TraceRecord<K, V, S, T>)>>()
-}
-
 /// Common test function to build and check the consistency circuit
 pub fn build_and_test_circuit(trace: Vec<TraceRecord<B256, B256, 32, 32>>, k: u32) {
-    // Initially, the trace is sorted by time_log
-    let trace = trace_with_index::<B256, B256, 32, 32, Fp>(trace);
-
-    // Sort this trace in address and time_log
-    let sorted_trace = sort_trace::<B256, B256, 32, 32, Fp>(trace.clone());
+    // Sort this trace (already sorted by time_log) in address and time_log order
+    let sorted_trace = sort_trace::<B256, B256, 32, 32>(trace.clone());
 
     let circuit = MemoryConsistencyCircuit::<Fp> {
         input: trace.clone(),
         shuffle: sorted_trace.clone(),
+        marker: PhantomData,
     };
 
     let prover = MockProver::run(k, &circuit, vec![]).expect("Cannot run the circuit");
@@ -248,16 +227,17 @@ mod tests {
         );
 
         // Initially, the trace is sorted by time_log
-        let trace = trace_with_index::<B256, B256, 32, 32, Fp>(vec![trace_0, trace_1, trace_2]);
+        let trace = vec![trace_0, trace_1, trace_2];
 
         // Sort this trace in address and time_log
-        let mut sorted_trace = sort_trace::<B256, B256, 32, 32, Fp>(trace.clone());
+        let mut sorted_trace = sort_trace::<B256, B256, 32, 32>(trace.clone());
         // Tamper the permutation
         sorted_trace.swap(0, 1);
 
         let circuit = MemoryConsistencyCircuit::<Fp> {
             input: trace.clone(),
             shuffle: sorted_trace.clone(),
+            marker: PhantomData,
         };
 
         let prover = MockProver::run(9, &circuit, vec![]).unwrap();

--- a/zkmemory/src/constraints/helper.rs
+++ b/zkmemory/src/constraints/helper.rs
@@ -226,13 +226,21 @@ mod tests {
             B256::from(5),
         );
 
+        let trace_3 = TraceRecord::<B256, B256, 32, 32>::new(
+            3,
+            0,
+            MemoryInstruction::Write,
+            B256::from(0x20),
+            B256::from(5),
+        );
+
         // Initially, the trace is sorted by time_log
         let trace = vec![trace_0, trace_1, trace_2];
 
         // Sort this trace in address and time_log
         let mut sorted_trace = sort_trace::<B256, B256, 32, 32>(trace.clone());
         // Tamper the permutation
-        sorted_trace.swap(0, 1);
+        sorted_trace[2] = trace_3;
 
         let circuit = MemoryConsistencyCircuit::<Fp> {
             input: trace.clone(),
@@ -240,7 +248,7 @@ mod tests {
             marker: PhantomData,
         };
 
-        let prover = MockProver::run(9, &circuit, vec![]).unwrap();
+        let prover = MockProver::run(10, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
     }
 

--- a/zkmemory/src/constraints/mod.rs
+++ b/zkmemory/src/constraints/mod.rs
@@ -8,7 +8,7 @@ pub mod gadgets;
 pub mod helper;
 /// Check the correctness of the original memory
 pub mod original_memory_circuit;
-/// Permutation circuit for trace record permutation check
+/// Permutation circuit for trace record permutation check.
 pub mod permutation_circuit;
 /// Check the correctness of memory sorting
 pub mod sorted_memory_circuit;

--- a/zkmemory/src/constraints/permutation_circuit.rs
+++ b/zkmemory/src/constraints/permutation_circuit.rs
@@ -1,3 +1,8 @@
+//! This module implements the Permutation Circuit which checks whether two arrays
+//! are permutations of each other without leaking information about the elements
+//! in these arrays and the permutation that links them.
+//! This implementation references the [PSE `shuffle` API](https://github.com/privacy-scaling-explorations/halo2/blob/bd385c36253cd1611785dd4ef10199234e2c64bc/halo2_proofs/examples/shuffle_api.rs)
+//! with modifications to suit the project's requirements.
 use crate::{
     base::Base,
     constraints::common::CircuitExtension,
@@ -36,7 +41,7 @@ pub struct ShuffleChip<F: Field + PrimeField> {
     _marker: PhantomData<F>,
 }
 
-/// Define that chip config struct
+/// Define the configuration for the shuffle chip.
 #[derive(Debug, Clone)]
 pub struct ShuffleConfig {
     input: Column<Fixed>,

--- a/zkmemory/src/constraints/permutation_circuit.rs
+++ b/zkmemory/src/constraints/permutation_circuit.rs
@@ -145,11 +145,9 @@ impl<F: Field + PrimeField> Circuit<F> for PermutationCircuit<F> {
 
     // Method: configure: this step is easily implemented by using shuffle API
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-        let input_idx = meta.advice_column();
         let input = meta.fixed_column();
-        let shuffle_idx = meta.advice_column();
         let shuffle = meta.advice_column();
-        ShuffleChip::configure(meta, input_idx, input, shuffle_idx, shuffle)
+        ShuffleChip::configure(meta, input, shuffle)
     }
 
     // Method: synthesize
@@ -162,15 +160,7 @@ impl<F: Field + PrimeField> Circuit<F> for PermutationCircuit<F> {
         layouter.assign_region(
             || "load inputs",
             |mut region| {
-                for (i, (input_idx, input)) in
-                    self.input_idx.iter().zip(self.input.iter()).enumerate()
-                {
-                    region.assign_advice(
-                        || "input_idx",
-                        shuffle_chip.config.input_0,
-                        i,
-                        || *input_idx,
-                    )?;
+                for (i, input) in self.input.iter().enumerate() {
                     region.assign_fixed(
                         || "input",
                         shuffle_chip.config.input_1,
@@ -185,15 +175,7 @@ impl<F: Field + PrimeField> Circuit<F> for PermutationCircuit<F> {
         layouter.assign_region(
             || "load shuffles",
             |mut region| {
-                for (i, (shuffle_idx, shuffle)) in
-                    self.shuffle_idx.iter().zip(self.shuffle.iter()).enumerate()
-                {
-                    region.assign_advice(
-                        || "shuffle_index",
-                        shuffle_chip.config.shuffle_0,
-                        i,
-                        || *shuffle_idx,
-                    )?;
+                for (i, shuffle) in shuffle.iter().enumerate() {
                     region.assign_advice(
                         || "shuffle_value",
                         shuffle_chip.config.shuffle_1,

--- a/zkmemory/src/constraints/permutation_circuit.rs
+++ b/zkmemory/src/constraints/permutation_circuit.rs
@@ -39,8 +39,8 @@ pub struct ShuffleChip<F: Field + PrimeField> {
 /// Define that chip config struct
 #[derive(Debug, Clone)]
 pub struct ShuffleConfig {
-    input_1: Column<Fixed>,
-    shuffle_1: Column<Advice>,
+    input: Column<Fixed>,
+    shuffle: Column<Advice>,
     s_input: Selector,
     s_shuffle: Selector,
 }
@@ -57,22 +57,22 @@ impl<F: Field + PrimeField> ShuffleChip<F> {
     /// Configure the gates
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
-        input_1: Column<Fixed>,
-        shuffle_1: Column<Advice>,
+        input: Column<Fixed>,
+        shuffle: Column<Advice>,
     ) -> ShuffleConfig {
         let s_shuffle = meta.complex_selector();
         let s_input = meta.complex_selector();
         meta.shuffle("two traces are permutation of each other", |meta| {
             let s_input = meta.query_selector(s_input);
             let s_shuffle = meta.query_selector(s_shuffle);
-            let input_1 = meta.query_fixed(input_1, Rotation::cur());
-            let shuffle_1 = meta.query_advice(shuffle_1, Rotation::cur());
-            vec![(s_input * input_1, s_shuffle * shuffle_1)]
+            let input = meta.query_fixed(input, Rotation::cur());
+            let shuffle = meta.query_advice(shuffle, Rotation::cur());
+            vec![(s_input * input, s_shuffle * shuffle)]
         });
 
         ShuffleConfig {
-            input_1,
-            shuffle_1,
+            input,
+            shuffle,
             s_input,
             s_shuffle,
         }
@@ -102,7 +102,7 @@ impl<F: Field + PrimeField> CircuitExtension<F> for PermutationCircuit<F> {
                 for (i, input) in self.input.iter().enumerate() {
                     region.assign_fixed(
                         || "input",
-                        shuffle_chip.config.input_1,
+                        shuffle_chip.config.input,
                         i,
                         || Value::known(*input),
                     )?;
@@ -117,7 +117,7 @@ impl<F: Field + PrimeField> CircuitExtension<F> for PermutationCircuit<F> {
                 for (i, shuffle) in self.shuffle.iter().enumerate() {
                     region.assign_advice(
                         || "shuffle_value",
-                        shuffle_chip.config.shuffle_1,
+                        shuffle_chip.config.shuffle,
                         i,
                         || *shuffle,
                     )?;
@@ -163,7 +163,7 @@ impl<F: Field + PrimeField> Circuit<F> for PermutationCircuit<F> {
                 for (i, input) in self.input.iter().enumerate() {
                     region.assign_fixed(
                         || "input",
-                        shuffle_chip.config.input_1,
+                        shuffle_chip.config.input,
                         i,
                         || Value::known(*input),
                     )?;
@@ -178,7 +178,7 @@ impl<F: Field + PrimeField> Circuit<F> for PermutationCircuit<F> {
                 for (i, shuffle) in self.shuffle.iter().enumerate() {
                     region.assign_advice(
                         || "shuffle_value",
-                        shuffle_chip.config.shuffle_1,
+                        shuffle_chip.config.shuffle,
                         i,
                         || *shuffle,
                     )?;

--- a/zkmemory/src/constraints/permutation_circuit.rs
+++ b/zkmemory/src/constraints/permutation_circuit.rs
@@ -327,7 +327,6 @@ mod tests {
         machine::{AbstractTraceRecord, MemoryInstruction, TraceRecord},
     };
     use ff::Field;
-    use group::ff::PrimeField;
     use halo2_proofs::circuit::Value;
     use halo2curves::pasta::{EqAffine, Fp};
     use rand::{seq::SliceRandom, Rng};
@@ -335,13 +334,7 @@ mod tests {
     use alloc::vec::Vec;
 
     // Randomly create a vector of 2-tuple of trace elements and an index value (for testing)
-    fn random_trace<
-        K: Base<S>,
-        V: Base<T>,
-        const S: usize,
-        const T: usize,
-        F: Field + PrimeField,
-    >(
+    fn random_trace<K: Base<S>, V: Base<T>, const S: usize, const T: usize>(
         size: u64,
     ) -> Vec<TraceRecord<K, V, S, T>> {
         (0..size)
@@ -401,7 +394,7 @@ mod tests {
         // Number of trace elements in a trace, min = 2^K.
         let trace_size = 50;
         let mut rng = rand::thread_rng();
-        let mut trace_buffer = random_trace::<B256, B256, 32, 32, Fp>(trace_size);
+        let mut trace_buffer = random_trace::<B256, B256, 32, 32>(trace_size);
 
         let input_trace = trace_buffer.clone();
         trace_buffer.shuffle(&mut rng);
@@ -446,7 +439,7 @@ mod tests {
         // Number of trace elements in a trace, min = 2^K.
         let trace_size = 50;
         let mut rng = rand::thread_rng();
-        let mut trace_buffer = random_trace::<B256, B256, 32, 32, Fp>(trace_size);
+        let mut trace_buffer = random_trace::<B256, B256, 32, 32>(trace_size);
 
         let input_trace = trace_buffer.clone();
         trace_buffer.shuffle(&mut rng);
@@ -470,7 +463,7 @@ mod tests {
         // Number of trace elements in a trace, min = 2^K.
         let trace_size = 50;
         let mut rng = rand::thread_rng();
-        let mut trace_buffer = random_trace::<B256, B256, 32, 32, Fp>(trace_size);
+        let mut trace_buffer = random_trace::<B256, B256, 32, 32>(trace_size);
         let input_trace = trace_buffer.clone();
         trace_buffer.shuffle(&mut rng);
         let mut shuffle_trace = trace_buffer.clone();


### PR DESCRIPTION
The original `shuffle` API in [PSE-Halo2](https://github.com/privacy-scaling-explorations/halo2/blob/bd385c36253cd1611785dd4ef10199234e2c64bc/halo2_proofs/examples/shuffle_api.rs#L34C1-L41C2) uses the `ShuffleConfig` struct which consists of 6 fields as follows:
```Rust
struct ShuffleConfig {
    input_0: Column<Advice>,
    input_1: Column<Fixed>,
    shuffle_0: Column<Advice>,
    shuffle_1: Column<Advice>,
    s_input: Selector,
    s_shuffle: Selector,
}
```
The shuffle circuit proves that `shuffle_0` is the permutation of `input_0` and `shuffle_1` is the permutation of `input_1`. Therefore, I suggest using only 4 fields as follows:
```Rust
struct ShuffleConfig {
    input: Column<Fixed>,
    shuffle: Column<Advice>,
    s_input: Selector,
    s_shuffle: Selector,
}
```
As a result, the `PermutationCircuit` struct can be initiated using only `input_trace: Vec<TraceRecord<K, V, S, T>>` and `shuffle_trace: Vec<TraceRecord<K, V, S, T>>`.
