### PR TITLE
docs: fix typo in attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="./assets/orochimaru.png" alter="Orochimaru desu?">
+    <img src="./assets/orochimaru.png" alt="Orochimaru desu?">
 </p>
 
 ## Orochimaru


### PR DESCRIPTION
`alter` was used instead of `alt`.
fixed it to avoid issues with HTML semantics.