### PR TITLE
fix: update LICENSE path in poseidon README

### DIFF
--- a/poseidon/README.md
+++ b/poseidon/README.md
@@ -4,6 +4,6 @@ Poseidon hash implementation in Rust.
 
 ## License
 
-This project licensed under the [Apache License, Version 2.0](LICENSE).
+This project licensed under the [Apache License, Version 2.0](../LICENSE).
 
 _build with ❤️ and 🦀_


### PR DESCRIPTION
Fix broken LICENSE link in poseidon/README.md by changing from
LICENSE to ../LICENSE to point to the root directory.