### PR TITLE
Enforce Poseidon hash correctness in MerkleTreeCircuit (fix #93)

### DIFF
--- a/zkmemory/src/commitment/merkle_tree.rs
+++ b/zkmemory/src/commitment/merkle_tree.rs
@@ -2,11 +2,11 @@
 
 extern crate alloc;
 use crate::commitment::commitment_scheme::CommitmentScheme;
-use alloc::{vec, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 use core::marker::PhantomData;
 use ff::{Field, PrimeField};
 use halo2_proofs::{
-    circuit::{Layouter, Region, SimpleFloorPlanner, Value},
+    circuit::{Layouter, SimpleFloorPlanner, Value},
     halo2curves::pasta::{EqAffine, Fp},
     plonk::{
         create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
@@ -25,70 +25,93 @@ use halo2_proofs::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
     },
 };
+use poseidon::circuit::PoseidonConfig;
+use poseidon::gadgets::Hash as PoseidonHashChip;
 use poseidon::poseidon_hash::{ConstantLength, Hash, OrchardNullifier, Spec};
 use rand_core::OsRng;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Debug)]
 /// Merkle tree config
-pub struct MerkleTreeConfig<F: Field + PrimeField> {
-    /// advice has 3 columns, the first column is the left input of the hash,
-    /// the right column is the right input of the hash, and the last column
-    /// is the output of the hash
-    advice: [Column<Advice>; 3],
+///
+/// The correctness of each level's Poseidon hash is enforced *inside* the circuit
+/// through an embedded [`PoseidonConfig`]. The running digest of a level is the
+/// output cell of the in-circuit hash of the previous level, so a prover cannot
+/// substitute a forged hash output (see issue #93).
+pub struct MerkleTreeConfig<F: Field + PrimeField, const W: usize, const R: usize> {
+    /// advice has 4 columns: `[digest, element, left, right]`.
+    /// `digest` is the running digest coming up from the previous level,
+    /// `element` is the sibling node of the current level, and `left`/`right`
+    /// are the (possibly swapped) inputs of the Poseidon hash of this level.
+    advice: [Column<Advice>; 4],
+    /// the index bit of the current level (0 if the running digest is the left
+    /// child, 1 if it is the right child).
     indices: Column<Advice>,
     /// the instance of the config, consisting of the leaf we would like to
     /// open, and the merkle root.
     pub instance: Column<Instance>,
-    /// the selectors
-    selector: Column<Fixed>,
-    selector_zero: Selector,
-    _marker0: PhantomData<F>,
+    /// selector enabling the boolean + conditional-swap gate on every level row.
+    selector: Selector,
+    /// in-circuit Poseidon hash sub-configuration, used to actually constrain
+    /// `output = poseidon(left, right)` for every level.
+    poseidon_config: PoseidonConfig<F, W, R>,
 }
 
-impl<F: Field + PrimeField> MerkleTreeConfig<F> {
-    fn configure(meta: &mut ConstraintSystem<F>, instance: Column<Instance>) -> Self {
-        let advice = [0; 3].map(|_| meta.advice_column());
+impl<F: Field + PrimeField, const W: usize, const R: usize> MerkleTreeConfig<F, W, R> {
+    fn configure<S: Spec<F, W, R>>(
+        meta: &mut ConstraintSystem<F>,
+        instance: Column<Instance>,
+    ) -> Self {
+        let advice = [0; 4].map(|_| meta.advice_column());
         let indices = meta.advice_column();
-        let selector = meta.fixed_column();
-        let selector_zero = meta.selector();
-        for i in advice {
-            meta.enable_equality(i);
+        let selector = meta.selector();
+        for column in advice {
+            meta.enable_equality(column);
         }
 
         let one = Expression::Constant(F::ONE);
 
-        // for i=0 indices[i] is equal to zero or one
-        // we handle i=0 seperately with selector_zero, since we are using
-        // a common selector for the other gates.
-        meta.create_gate("indices must be 0 or 1", |meta| {
-            let selector_zero = meta.query_selector(selector_zero);
-            let indices = meta.query_advice(indices, Rotation::cur());
-            vec![selector_zero * indices.clone() * (one.clone() - indices)]
+        // For every level we constrain, in a single row:
+        //   * the index bit is boolean,
+        //   * `left`  = digest + bit * (element - digest),
+        //   * `right` = element + bit * (digest - element).
+        // i.e. (left, right) = (digest, element) when bit = 0, and the swapped
+        // pair (element, digest) when bit = 1. This binds the hash inputs of the
+        // level to the running digest and the sibling.
+        meta.create_gate("boolean index bit and conditional swap", |meta| {
+            let selector = meta.query_selector(selector);
+            let digest = meta.query_advice(advice[0], Rotation::cur());
+            let element = meta.query_advice(advice[1], Rotation::cur());
+            let left = meta.query_advice(advice[2], Rotation::cur());
+            let right = meta.query_advice(advice[3], Rotation::cur());
+            let bit = meta.query_advice(indices, Rotation::cur());
+            vec![
+                selector.clone() * bit.clone() * (one.clone() - bit.clone()),
+                selector.clone()
+                    * (left - (digest.clone() + bit.clone() * (element.clone() - digest.clone()))),
+                selector * (right - (element.clone() + bit * (digest - element))),
+            ]
         });
 
-        // for all i>=1 indices[i] is equal to zero or one
-        meta.create_gate("indices must be 0 or 1", |meta| {
-            let indices = meta.query_advice(indices, Rotation::cur());
-            let selector = meta.query_fixed(selector, Rotation::cur());
-            vec![selector * indices.clone() * (one.clone() - indices)]
-        });
-
-        // if indices[i]=0 then advice_cur[i][0]=advice_cur[i-1][2]
-        // otherwise advice_cur[i][1]=advice_cur[i-1][2]
-        meta.create_gate(
-            "output of the current layer is equal to the left or right input of the next layer",
-            |meta| {
-                let advice_cur = advice.map(|x| meta.query_advice(x, Rotation::cur()));
-                let advice_prev = advice.map(|x| meta.query_advice(x, Rotation::prev()));
-                let indices = meta.query_advice(indices, Rotation::cur());
-                let selector = meta.query_fixed(selector, Rotation::cur());
-                vec![
-                    selector
-                        * ((one - indices.clone())
-                            * (advice_cur[0].clone() - advice_prev[2].clone())
-                            + indices * (advice_cur[1].clone() - advice_prev[2].clone())),
-                ]
-            },
+        // Embed the in-circuit Poseidon hash configuration. Its gates enforce
+        // that the squeezed output is the correct Poseidon hash of the absorbed
+        // inputs, which is exactly the correctness property missing before.
+        let state = (0..W)
+            .map(|_| meta.advice_column())
+            .collect::<Vec<Column<Advice>>>();
+        let partial_sbox = meta.advice_column();
+        let rc_a = (0..W)
+            .map(|_| meta.fixed_column())
+            .collect::<Vec<Column<Fixed>>>();
+        let rc_b = (0..W)
+            .map(|_| meta.fixed_column())
+            .collect::<Vec<Column<Fixed>>>();
+        meta.enable_constant(rc_b[0]);
+        let poseidon_config = PoseidonConfig::<F, W, R>::configure::<S>(
+            meta,
+            state.try_into().expect("could not load poseidon state"),
+            partial_sbox,
+            rc_a.try_into().expect("could not load rc_a"),
+            rc_b.try_into().expect("could not load rc_b"),
         );
 
         MerkleTreeConfig {
@@ -96,8 +119,7 @@ impl<F: Field + PrimeField> MerkleTreeConfig<F> {
             indices,
             instance,
             selector,
-            selector_zero,
-            _marker0: PhantomData,
+            poseidon_config,
         }
     }
 }
@@ -121,7 +143,7 @@ pub struct MerkleTreeCircuit<
 impl<S: Spec<F, W, R> + Clone, F: Field + PrimeField, const W: usize, const R: usize> Circuit<F>
     for MerkleTreeCircuit<S, F, W, R>
 {
-    type Config = MerkleTreeConfig<F>;
+    type Config = MerkleTreeConfig<F, W, R>;
     type FloorPlanner = SimpleFloorPlanner;
 
     fn without_witnesses(&self) -> Self {
@@ -136,7 +158,7 @@ impl<S: Spec<F, W, R> + Clone, F: Field + PrimeField, const W: usize, const R: u
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let instance = meta.instance_column();
         meta.enable_equality(instance);
-        MerkleTreeConfig::<F>::configure(meta, instance)
+        MerkleTreeConfig::<F, W, R>::configure::<S>(meta, instance)
     }
 
     fn synthesize(
@@ -145,115 +167,75 @@ impl<S: Spec<F, W, R> + Clone, F: Field + PrimeField, const W: usize, const R: u
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
         assert_eq!(self.indices.len(), self.elements.len());
-        let mut v = vec![self.leaf];
 
-        layouter.assign_region(
-            || "Merkle proof",
+        // Load the leaf as the initial running digest and bind it to the first
+        // public input.
+        let mut digest = layouter.assign_region(
+            || "load leaf",
             |mut region| {
-                for i in 0..self.indices.len() {
-                    let digest = self.assign(v[i], &mut region, config, i);
-                    v.push(digest.expect("cannot get digest"));
-                }
-                Ok(())
+                region.assign_advice(|| "leaf", config.advice[0], 0, || Value::known(self.leaf))
             },
         )?;
+        layouter.constrain_instance(digest.cell(), config.instance, 0)?;
 
-        let leaf_cell = layouter.assign_region(
-            || "assign leaf",
-            |mut region| {
-                region.assign_advice(
-                    || "assign leaf",
-                    config.advice[0],
-                    0,
-                    || Value::known(self.leaf),
-                )
-            },
-        )?;
+        // Walk up the tree. At each level we recompute the parent hash *inside*
+        // the circuit and use its output cell as the new running digest, so a
+        // prover cannot substitute a fake output.
+        for i in 0..self.indices.len() {
+            let index = self.indices[i];
+            let element = self.elements[i];
 
-        let digest = layouter.assign_region(
-            || "assign root",
-            |mut region| {
-                region.assign_advice(
-                    || "assign root",
-                    config.advice[0],
-                    0,
-                    || Value::known(v[self.indices.len()]),
-                )
-            },
-        )?;
+            // Assign the swap row and derive the (left, right) inputs of the hash.
+            let (left, right) = layouter.assign_region(
+                || format!("merkle level {}", i),
+                |mut region| {
+                    config.selector.enable(&mut region, 0)?;
 
-        layouter.constrain_instance(leaf_cell.cell(), config.instance, 0)?;
+                    // Copy the running digest in; this constrains it to be equal
+                    // to the previous level's hash output (or the leaf).
+                    let digest_cell =
+                        digest.copy_advice(|| "digest", &mut region, config.advice[0], 0)?;
+                    let element_cell = region.assign_advice(
+                        || "element",
+                        config.advice[1],
+                        0,
+                        || Value::known(element),
+                    )?;
+                    region.assign_advice(|| "index", config.indices, 0, || Value::known(index))?;
+
+                    // (left, right) = (digest, element) if bit == 0 else (element, digest).
+                    let (left_val, right_val) = if index == F::ZERO {
+                        (digest_cell.value().copied(), element_cell.value().copied())
+                    } else {
+                        (element_cell.value().copied(), digest_cell.value().copied())
+                    };
+                    let left =
+                        region.assign_advice(|| "left input", config.advice[2], 0, || left_val)?;
+                    let right = region.assign_advice(
+                        || "right input",
+                        config.advice[3],
+                        0,
+                        || right_val,
+                    )?;
+                    Ok((left, right))
+                },
+            )?;
+
+            // Enforce digest = poseidon(left, right) with the in-circuit chip.
+            let hasher = PoseidonHashChip::<F, S, ConstantLength<2>, W, R>::init(
+                config.poseidon_config.clone(),
+                layouter.namespace(|| format!("init poseidon {}", i)),
+            )?;
+            digest = hasher.hash(
+                layouter.namespace(|| format!("poseidon hash {}", i)),
+                [left, right],
+            )?;
+        }
+
+        // The final running digest is the Merkle root; bind it to the second
+        // public input.
         layouter.constrain_instance(digest.cell(), config.instance, 1)?;
         Ok(())
-    }
-}
-
-impl<S: Spec<F, W, R> + Clone, F: Field + PrimeField, const W: usize, const R: usize>
-    MerkleTreeCircuit<S, F, W, R>
-{
-    // Assign the elements in the path into the witness table
-    fn assign(
-        &self,
-        digest: F,
-        region: &mut Region<'_, F>,
-        config: MerkleTreeConfig<F>,
-        offset: usize,
-    ) -> Result<F, Error> {
-        if offset != 0 {
-            region.assign_fixed(
-                || "selector",
-                config.selector,
-                offset,
-                || Value::known(F::ONE),
-            )?;
-            config.selector_zero.enable(region, offset)?;
-        }
-        let hash: F;
-        region.assign_advice(
-            || "indices",
-            config.indices,
-            offset,
-            || Value::known(self.indices[offset]),
-        )?;
-
-        // assign the left input of the hash
-        if self.indices[offset] == F::ZERO {
-            region.assign_advice(
-                || "left input",
-                config.advice[0],
-                offset,
-                || Value::known(digest),
-            )?;
-            // assign the right input of the hash
-            region.assign_advice(
-                || "right input",
-                config.advice[1],
-                offset,
-                || Value::known(self.elements[offset]),
-            )?;
-            // assign the output of the hash
-            hash =
-                Hash::<F, S, ConstantLength<2>, W, R>::init().hash([digest, self.elements[offset]]);
-
-            region.assign_advice(|| "output", config.advice[2], offset, || Value::known(hash))?;
-        } else {
-            region.assign_advice(
-                || "left input",
-                config.advice[0],
-                offset,
-                || Value::known(self.elements[offset]),
-            )?;
-            region.assign_advice(
-                || "right input",
-                config.advice[1],
-                offset,
-                || Value::known(digest),
-            )?;
-            hash =
-                Hash::<F, S, ConstantLength<2>, W, R>::init().hash([self.elements[offset], digest]);
-            region.assign_advice(|| "output", config.advice[2], offset, || Value::known(hash))?;
-        }
-        Ok(hash)
     }
 }
 
@@ -431,13 +413,22 @@ mod tests {
     extern crate alloc;
     use super::MerkleTreeCircuit;
     use crate::commitment::commitment_scheme::CommitmentScheme;
-    use crate::commitment::merkle_tree::{merkle_tree_commit_fp, MerkleTreeProver, MerkleWitness};
-    use alloc::vec;
+    use crate::commitment::merkle_tree::{
+        merkle_tree_commit_fp, MerkleTreeConfig, MerkleTreeProver, MerkleWitness,
+    };
+    use alloc::{vec, vec::Vec};
     use core::marker::PhantomData;
-    use halo2_proofs::{dev::MockProver, halo2curves::pasta::Fp};
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        dev::MockProver,
+        halo2curves::pasta::{EqAffine, Fp},
+        plonk::{create_proof, Circuit, ConstraintSystem, Error},
+        poly::ipa::{commitment::IPACommitmentScheme, multiopen::ProverIPA},
+        transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    };
     use poseidon::poseidon_hash::*;
     use rand::{thread_rng, Rng};
-    use rand_core::RngCore;
+    use rand_core::{OsRng, RngCore};
 
     #[test]
     fn test_correct_merkle_proof() {
@@ -607,5 +598,105 @@ mod tests {
         let is_valid = circuit.verify(commitment, opening, witness);
 
         assert!(is_valid, "Verification should succeed for valid opening");
+    }
+
+    /// A circuit reproducing the attack from issue #93: it reuses the exact
+    /// same constraint system as [`MerkleTreeCircuit`] but its `synthesize`
+    /// ignores the Poseidon hash chain and constrains an arbitrary, forged root
+    /// to the public instance. With the hash correctness now enforced inside the
+    /// verifying key, a proof produced by this circuit (using the honest proving
+    /// key) must be rejected by the verifier.
+    #[derive(Clone)]
+    struct FakeMerkleTreeCircuit {
+        leaf: Fp,
+        fake_root: Fp,
+    }
+
+    impl Circuit<Fp> for FakeMerkleTreeCircuit {
+        type Config = MerkleTreeConfig<Fp, 3, 2>;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            self.clone()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            let instance = meta.instance_column();
+            meta.enable_equality(instance);
+            MerkleTreeConfig::<Fp, 3, 2>::configure::<OrchardNullifier>(meta, instance)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<Fp>,
+        ) -> Result<(), Error> {
+            let leaf_cell = layouter.assign_region(
+                || "leaf",
+                |mut region| {
+                    region.assign_advice(|| "leaf", config.advice[0], 0, || Value::known(self.leaf))
+                },
+            )?;
+            layouter.constrain_instance(leaf_cell.cell(), config.instance, 0)?;
+
+            // Directly constrain a forged root to the public instance, without
+            // ever computing a Poseidon hash.
+            let root_cell = layouter.assign_region(
+                || "fake root",
+                |mut region| {
+                    region.assign_advice(
+                        || "fake root",
+                        config.advice[0],
+                        0,
+                        || Value::known(self.fake_root),
+                    )
+                },
+            )?;
+            layouter.constrain_instance(root_cell.cell(), config.instance, 1)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_fake_merkle_proof_is_rejected() {
+        let leaf = 0u64;
+        let k = 10;
+        let indices = [0u64, 0u64, 1u64, 1u64];
+        let elements = [3u64, 4u64, 5u64, 6u64];
+        // The forged root the attacker wants the verifier to accept.
+        let fake_root = Fp::from(42u64);
+
+        // Honest setup: build the proving key from the real MerkleTreeCircuit.
+        let witness = MerkleWitness::new(leaf, elements, indices);
+        let prover = MerkleTreeProver::new(k, witness);
+
+        // Attacker forges a proof for `fake_root` reusing the honest proving key.
+        let fake_circuit = FakeMerkleTreeCircuit {
+            leaf: Fp::from(leaf),
+            fake_root,
+        };
+        let public_inputs = [Fp::from(leaf), fake_root];
+        let mut transcript =
+            Blake2bWrite::<Vec<u8>, EqAffine, Challenge255<EqAffine>>::init(vec![]);
+        create_proof::<
+            IPACommitmentScheme<EqAffine>,
+            ProverIPA<'_, EqAffine>,
+            Challenge255<EqAffine>,
+            OsRng,
+            Blake2bWrite<Vec<u8>, EqAffine, Challenge255<EqAffine>>,
+            FakeMerkleTreeCircuit,
+        >(
+            &prover.params,
+            &prover.pk,
+            &[fake_circuit],
+            &[&[&public_inputs[..]]],
+            OsRng,
+            &mut transcript,
+        )
+        .expect("Failed to create fake proof");
+        let fake_proof = transcript.finalize();
+
+        let is_valid = prover.verify(fake_proof, public_inputs.to_vec());
+        assert!(!is_valid, "Fake merkle proof must be rejected");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #93 — a soundness bug in `zkmemory/src/commitment/merkle_tree.rs` that allowed forging a **fake Merkle opening proof**.

### Root cause
`MerkleTreeConfig::configure` only enforced that (a) index bits are boolean and (b) each level's output equals the next level's input. The Poseidon hash itself was computed **off-circuit** in `assign` (`Hash::init().hash(...)`) and written as an *unconstrained* witness into the `output` advice column. Nothing forced `output == poseidon(left, right)`, so a malicious prover could place an arbitrary value in the output column and verify against a forged root. Two related gaps: the public leaf and root were assigned in standalone regions and never copy-constrained to the actual hash chain.

### Fix
Recompute every level's hash **inside the circuit** using the existing in-circuit Poseidon chip (`poseidon::circuit::PoseidonConfig` + `poseidon::gadgets::Hash`) and use its output cell as the running digest. Hash correctness is now enforced by the Poseidon gates and copy constraints baked into the verifying key, so it cannot be bypassed by swapping in a different `synthesize`. Additionally:

- A boolean + conditional-swap gate binds the `(left, right)` hash inputs to the running digest and the sibling, keyed on the index bit.
- The leaf and the final root are tied to the public instance via copy constraints (`copy_advice` of the running digest links each level to the previous hash output).

### Tests
- All existing Merkle tests still pass (honest proofs verify; wrong root / wrong path / non-boolean indices are rejected).
- Added `test_fake_merkle_proof_is_rejected`, which reproduces the exploit from the issue — a circuit that constrains an arbitrary root while reusing the honest proving key — and asserts the verifier now **rejects** it.

```
running 9 tests
test commitment::merkle_tree::tests::test_correct_merkle_proof ... ok
test commitment::merkle_tree::tests::test_correct_merkle_proof_part2 ... ok
test commitment::merkle_tree::tests::test_correct_merkle_proof_commitment_scheme_trait ... ok
test commitment::merkle_tree::tests::test_wrong_merkle_proof ... ok
test commitment::merkle_tree::tests::test_wrong_merkle_part2 ... ok
test commitment::merkle_tree::tests::test_invalid_indices ... ok
test commitment::merkle_tree::tests::test_invalid_indices_part2 ... ok
test commitment::merkle_tree::tests::test_merkle_proof_real_prover ... ok
test commitment::merkle_tree::tests::test_fake_merkle_proof_is_rejected ... ok

test result: ok. 9 passed; 0 failed
```

`cargo fmt --all -- --check` and `cargo clippy --all -- -D warnings` are clean.

### Note for triage
The issue carries two comments (from a non-collaborator account) advising "do not attempt an automated fix." The change here is a standard, well-understood ZK correctness fix — adding the missing in-circuit hash constraint — verified end-to-end with a regression test that demonstrates the forgery is now rejected. It of course warrants cryptographic review before merge.