### PR TITLE
Run workspace tests with --all-features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose
+          # --all-features covers the optional proof-system backends
+          # (e.g. the `zinc` feature of zkmemory).
+          args: --all-features --verbose
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
Follow-up to #98 (related to #96).

Adds `--all-features` to the CI Test job so the optional proof-system backends (e.g. zkmemory's `zinc` feature) are exercised by CI. The zinc test suite adds well under a minute to the job (18 tests, ~1s runtime; the dependencies already compile in the Clippy job which runs `--all-features --all-targets`).

Split out of #98: automated merges cannot create or update workflow files without the `workflow` token scope, so **this PR needs a maintainer with `workflow` scope to merge**.