### PR TITLE
Enforce the full Halo2 composed statement in the Zinc+ backend

### DIFF
--- a/zkmemory/src/backend.rs
+++ b/zkmemory/src/backend.rs
@@ -16,9 +16,13 @@
 //! ```
 //!
 //! Every backend consumes the *time-ordered* execution trace exactly as
-//! returned by [`crate::machine::AbstractMachine::trace`] and internally
-//! derives whatever sorted/converted representation it needs. The backends
-//! differ in the artifacts they produce and in their trust profile:
+//! returned by [`crate::machine::AbstractMachine::trace`] (`time_log`s
+//! starting at zero and strictly increasing) and internally derives
+//! whatever sorted/converted representation it needs. Both backends prove
+//! the same composed statement — original-trace time consistency,
+//! sorted-trace memory consistency and the permutation link between the two
+//! orderings — but differ in the artifacts they produce and in their trust
+//! profile:
 //!
 //! | backend | proof artifact | trusted setup | zero-knowledge | status |
 //! |---------|----------------|---------------|----------------|--------|
@@ -144,9 +148,11 @@ impl MemoryConsistencyBackend for Halo2Backend {
     }
 }
 
-/// The Zinc+ backend: produces a succinct, transparent SNARK for the
-/// sorted-trace consistency statement. **Not zero-knowledge** — see
-/// [`crate::zincplus`] for the security discussion.
+/// The Zinc+ backend: produces a succinct, transparent SNARK for the full
+/// composed memory-consistency statement (original-trace time consistency,
+/// sorted-trace consistency, and their permutation link via a deterministic
+/// Beneš network). **Not zero-knowledge** — see [`crate::zincplus`] for the
+/// security discussion.
 #[cfg(feature = "zinc")]
 #[derive(Clone, Debug, Default)]
 pub struct ZincPlusBackend;

--- a/zkmemory/src/zincplus/README.md
+++ b/zkmemory/src/zincplus/README.md
@@ -12,6 +12,7 @@ zkmemory/src/zincplus/
 ├── mod.rs        module root, public re-exports
 ├── types.rs      concrete Zinc+ protocol type parameters (field, codes, widths)
 ├── uair.rs       the memory-consistency UAIR + witness builder
+├── benes.rs      Beneš-network routing for the permutation argument
 ├── prover.rs     prove / verify entry points, proof (de)serialization, errors
 ├── testcases.rs  positive and negative (soundness) tests
 └── README.md     this file
@@ -41,6 +42,12 @@ let zinc = ZincPlusBackend;
 zinc.verify(&zinc.prove(&trace)?)?;
 ```
 
+The input trace must satisfy the same contract the Halo2
+`OriginalMemoryCircuit` places on the original trace: records in execution
+order, `time_log[0] = 0`, strictly increasing `time_log`s (gaps allowed).
+Traces produced by [`machine.trace()`](../machine.rs) satisfy this by
+construction.
+
 Build with `cargo build -p zkmemory --features zinc`. The feature requires a
 `std` environment and Rust ≥ 1.85 (Zinc+ is an edition-2024 workspace); the
 repository toolchain is pinned accordingly in [`rust-toolchain`](../../../rust-toolchain).
@@ -62,80 +69,92 @@ Fiat-Shamir transcript.
 
 ## The statement proven
 
-The prover commits to a memory trace of `2^num_vars − 1` rows (the machine's
-records sorted by `(address, time_log)`, followed by benign padding rows) and
-proves, for every pair of adjacent rows:
+The proof attests knowledge of a witness containing *two orderings of the
+same trace* — the time-ordered original trace `O` and its
+`(address, time_log)`-sorted permutation `S`, each padded to `2^num_vars`
+rows — satisfying all three sub-statements of the composed Halo2
+`MemoryConsistencyCircuit`:
 
-| # | constraint | meaning |
-|---|-----------|---------|
-| 1 | `is_first · (instr − 1) = 0` | the first access of the trace is a write |
-| 2 | `instr' · (instr' − 1) = 0` | instructions are boolean (0 = read, 1 = write) |
-| 3 | `s_j · (s_j − 1) = 0` | first-difference selectors are boolean |
-| 4 | `Σ_j s_j = 1` | exactly one first-difference position |
-| 5 | `(1 − Σ_{l≤j} s_l) · (L'_j − L_j) = 0` | limbs before the first difference are equal |
-| 6 | `Σ_j s_j·(L'_j − L_j) − 1 − r ∈ (X − 2)` | the first differing limb strictly increases |
-| 7 | `w = (s_8 + s_9) · (instr' − 1)` | helper: `w = −1` iff *read at unchanged address* |
-| 8 | `w · (value'_j − value_j) = 0` | a read returns the previous value at that address |
-| 9 | `(1 − s_8 − s_9) · (instr' − 1) = 0` | the first access to a new address is a write |
+| sub-statement | Halo2 circuit | Zinc+ constraints |
+|---------------|---------------|-------------------|
+| original-trace consistency: `time_log[0] = 0`, `time_log[i] < time_log[i+1]` | `OriginalMemoryCircuit` | `is_first` pins row 0's time limbs; a one-hot limb selector + slack limb enforce the strict `u64` increase |
+| sorted-trace consistency: `(address, time_log)` strictly increases, first access (overall and per address) is a write, instructions boolean, reads return the previous value at the address | `SortedMemoryCircuit` | the lookup-free lexicographic comparison and read-check constraints described in [`uair.rs`](uair.rs) |
+| `S` is a permutation of `O` | `PermutationCircuit` (PLONK shuffle) | a **Beneš switching network**: `2v - 1` layers of boolean-selected conditional swaps between rows `i` and `i + 2^k`, carrying the full record payload from `S` (network input) to `O` (network output) |
 
-where `L_0..L_9` is the lexicographic limb vector `address ‖ time_log`
-(32-bit limbs, most significant first) and primes denote the next row.
-Constraints 3–6 together are a lookup-free strict lexicographic comparison:
-`s` selects the first differing limb, everything before it must be equal, and
-the selected limb must grow by `1 + r` where `r` is a committed 32-bit value.
-These are semantically the same constraints as the Halo2
-`SortedMemoryCircuit` (`src/constraints/sorted_memory_circuit.rs`).
+Both traces are witnesses; like the composed Halo2 circuit, the statement
+has no trace-dependent public inputs (the verifier reconstructs the fixed
+`is_first` and bit-indicator selector columns itself).
 
-Addresses, values and `time_log`s live in *binary polynomial* columns:
-`BinaryPoly<32>` cells whose 32 coefficients are proven boolean by Zinc+'s
-built-in booleanity argument, so every limb is range-checked to `u32` for
-free — no lookup tables are needed anywhere.
+Randomized permutation arguments (PLONK shuffle, LogUp) are not expressible
+in Zinc+ — there is no lookup layer yet, no verifier-randomness columns, and
+committed cells are small integers fixed before the random prime is sampled,
+so a grand-product accumulator over the proof field cannot even be
+materialized. The Beneš network sidesteps randomness entirely: switch
+equations are cell-exact, so each network state is *exactly* a permutation
+of the previous one, and `multiset(O) = multiset(S)` holds with no soundness
+error beyond the (negligible) probability that a small nonzero integer
+vanishes mod the ~192-bit Fiat-Shamir-sampled prime. Routing bits are free
+witnesses: a malicious router can only fail to prove, never prove a false
+statement. This is the established deterministic RAM-checking technique of
+challenge-less proof systems (Pantry, Buffet, xJsnark).
+
+Addresses, values, `time_log`s and `stack_depth`s live in *binary
+polynomial* columns: `BinaryPoly<32>` cells whose 32 coefficients are proven
+boolean by Zinc+'s built-in booleanity argument, so every limb is
+range-checked to `u32` for free — no lookup tables are needed anywhere.
 
 Zinc+ exempts the very last row from constraints (its built-in last-row
 selector); the witness builder therefore always keeps at least one padding
 row, so **no real record ever occupies the exempt row**. Padding rows replay
-the last record as reads with increasing `time_log`s, which satisfies every
-constraint.
-
-The only public input is the `is_first` column (`[1, 0, 0, …]`), which the
-verifier reconstructs itself; it is absorbed into the Fiat-Shamir transcript
-by the protocol before any challenge is drawn.
+the last *sorted* record as reads with `time_log`s continuing past the
+global maximum, which satisfies both orderings' constraints and keeps the
+two padded multisets equal. The exemption opens no hole in the network
+either: row `2^v - 1` has every index bit set, so it is never the anchor
+(upper) row of any switch, and all constraints binding it are anchored at
+non-exempt rows.
 
 ## Security status — differences from the Halo2 backend
 
-Users must understand three deliberate limitations of this v1 integration:
+Users must understand two deliberate limitations of this integration:
 
 1. **No zero-knowledge.** Zinc+ currently provides succinctness and
    transparency but no hiding: witness columns are committed and opened
    without masking. Treat the proof as potentially revealing the entire
    trace. Use the Halo2 backend when privacy is required.
 
-2. **No in-SNARK permutation link.** The Halo2 circuit additionally proves
-   that the sorted trace is a *permutation* of a time-ordered original trace
-   (via PLONK's shuffle argument) and that the original trace's `time_log`s
-   start at zero and strictly increase. Zinc+ has no permutation or lookup
-   argument yet (upstream's lookup layer is scaffolded but explicitly
-   unimplemented), so those two sub-statements are **not** enforced here.
-   Note that the composed Halo2 circuit has *zero public inputs* — both
-   traces are witnesses — so its externally visible statement is "the prover
-   knows a consistent trace", which the Zinc+ backend also delivers. The gap
-   matters once the memory argument must be *linked to an execution proof*
-   (a zkVM composing CPU and memory arguments): that linkage needs the
-   permutation argument and awaits upstream support.
-
-3. **Research-grade upstream.** Zinc+ is unaudited and marked by its authors
+2. **Research-grade upstream.** Zinc+ is unaudited and marked by its authors
    as for research/educational use. The dependency is pinned to one reviewed
    revision (see `[workspace.dependencies]`), and the security parameters in
    [`types.rs`](types.rs) (repetition factor 8, 100 column openings, 192-bit
    sampled prime) are the upstream research defaults, not audited production
    parameters.
 
-Within those boundaries the encoding itself is designed to be sound; the
-constraint-by-constraint argument is documented in [`uair.rs`](uair.rs)
-(module docs, "Constraint soundness sketch") and exercised by negative tests
-in [`testcases.rs`](testcases.rs) (stale reads, reads of unwritten
-addresses, first-access reads, tampered/truncated proofs, duplicated
-`time_log`s).
+The earlier v1 limitation — no in-SNARK permutation link between the sorted
+and original traces — is **resolved**: the Beneš network enforces the full
+composed Halo2 statement. The constraint-by-constraint soundness argument is
+documented in [`uair.rs`](uair.rs) (module docs) and exercised by negative
+tests in [`testcases.rs`](testcases.rs), including direct witness-tampering
+attacks on the network states, switch bits, both trace orderings and the
+transition slacks.
+
+## Performance notes
+
+The deterministic permutation argument is paid for in trace width: the
+network adds `2v` states of 21 binary columns each (plus one switch column
+per layer), so the committed trace has `~42v + 2` binary columns instead of
+the ~20 of the consistency-only v1 backend. Measured on commodity hardware
+(release mode, single-threaded): 200 records (`v = 8`) prove in ~1.3 s and
+verify in ~0.12 s with a ~9 MiB proof; 900 records (`v = 10`) prove in
+~6.4 s and verify in ~0.2 s with a ~11.5 MiB proof. Linear-code commitments
+have large constants, so proofs are far bigger than pairing-based SNARK
+proofs. The verifier additionally pays `O(2^{v-1})` field operations per
+large-stride shifted column when evaluating Zinc+'s shift predicates, which
+is why [`MAX_NUM_VARS`](uair.rs) is 16 (`≤ 65 535` records): beyond that,
+verification time becomes impractical and the permutation argument should
+instead migrate to upstream's lookup layer once it lands (see below).
+
+The upstream `parallel` (rayon) and `simd` features can be forwarded later
+if throughput becomes a concern.
 
 ## Migration plan (tracking upstream Zinc+ maturity)
 
@@ -146,12 +165,10 @@ progress can be adopted incrementally:
 - **When Zinc+ gains zero-knowledge** (witness masking): bump the pinned
   revision, enable the hiding mode in `types.rs`/`prover.rs`; the UAIR and
   the public API stay unchanged.
-- **When Zinc+ lands its lookup/LogUp layer**: add the permutation link —
-  commit the time-ordered trace next to the sorted one and prove multiset
-  equality plus the original-trace time ordering (`time[0] = 0`,
-  `time[i+1] > time[i]`), reaching full parity with the Halo2 statement.
-  The column layout in `uair.rs` was chosen so the original-trace columns
-  can be appended without disturbing the existing indices.
+- **When Zinc+ lands its lookup/LogUp layer**: replace the Beneš network
+  with a randomized multiset argument to reclaim the `~40v` extra committed
+  columns and lift `MAX_NUM_VARS`; the statement and public API stay
+  unchanged.
 - **When upstream publishes audited parameters**: update `types.rs`
   accordingly (`REP_FACTOR`, `NUM_COLUMN_OPENINGS`, field size).
 - **Halo2 parity work in the other direction**: the Halo2 backend currently
@@ -159,15 +176,3 @@ progress can be adopted incrementally:
   prover just for the permutation sub-circuit); giving it a real
   transferable proof artifact would make the two backends fully
   interchangeable behind the trait.
-
-## Performance notes
-
-Proving is dominated by the Zip+ commitments over `2^num_vars` rows and
-32 committed columns. The trace is padded to the next power of two (minimum
-8 rows, maximum `2^24`); proving a few hundred records takes on the order of
-seconds in release mode on commodity hardware, and verification is
-milliseconds. Proof size is where the trade-off shows: linear-code
-commitments have large constants (the 8-record example proof is ≈560 KiB —
-"succinct" asymptotically, far bigger than a pairing-based SNARK proof).
-The upstream `parallel` (rayon) and `simd` features can be forwarded later
-if throughput becomes a concern.

--- a/zkmemory/src/zincplus/benes.rs
+++ b/zkmemory/src/zincplus/benes.rs
@@ -1,0 +1,309 @@
+//! Beneš-network routing for the deterministic permutation argument.
+//!
+//! A Beneš network on `2^v` wires consists of `2v - 1` layers of 2×2
+//! conditional-swap switches arranged in a butterfly + inverse-butterfly
+//! pattern and can realize *every* permutation of its inputs. The
+//! memory-consistency UAIR ([`super::uair`]) lays the network out
+//! horizontally — one trace row per wire, one column group per network
+//! state — and constrains each layer with boolean-selected swap equations,
+//! which proves that the sorted trace is an exact permutation of the
+//! original (time-ordered) trace without any random challenge.
+//!
+//! This module contains the *prover-side* routing: computing switch
+//! settings that realize a given permutation. Routing only affects
+//! completeness — the UAIR constraints enforce that the committed states
+//! form *some* permutation regardless of how the switches are set — so a
+//! routing bug here can only make honest proving fail, never admit a false
+//! statement.
+//!
+//! # Topology
+//!
+//! For `v ≥ 1`, layer `ℓ ∈ [0, 2v - 1)` pairs wire `i` with wire
+//! `i + 2^{k_ℓ}` for every `i` whose bit `k_ℓ` is zero (the *upper* wire of
+//! the switch), where
+//!
+//! ```text
+//! k_ℓ = v - 1 - ℓ   for ℓ < v      (butterfly half)
+//! k_ℓ = ℓ - v + 1   for ℓ ≥ v      (inverse-butterfly half)
+//! ```
+//!
+//! i.e. the stride-bit sequence is `v-1, v-2, …, 1, 0, 1, …, v-1`. A switch
+//! bit of `1` swaps the pair, `0` passes it through.
+//!
+//! The recursive structure: the outermost entry layer (`k = v-1`) splits
+//! the wires into a *top* sub-network (wires with bit `v-1` = 0) and a
+//! *bottom* sub-network (bit `v-1` = 1), each a Beneš network on `2^{v-1}`
+//! wires; the outermost exit layer (`k = v-1` again) merges them. Because
+//! sub-network wires share their fixed high bit, pairing by lower bits
+//! never crosses sub-networks.
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+
+/// The stride-bit index `k_ℓ` of layer `ℓ` in a Beneš network on `2^v`
+/// wires (see the module documentation).
+///
+/// # Panics
+///
+/// Panics when `v == 0` or `layer >= 2v - 1`; both indicate an internal
+/// logic error in the caller.
+pub(crate) fn stride_bit(v: usize, layer: usize) -> usize {
+    assert!(v >= 1, "a Beneš network needs at least 2 wires");
+    assert!(layer < 2 * v - 1, "layer {layer} out of range for v = {v}");
+    if layer < v {
+        v - 1 - layer
+    } else {
+        layer - v + 1
+    }
+}
+
+/// Number of layers of a Beneš network on `2^v` wires.
+pub(crate) fn num_layers(v: usize) -> usize {
+    assert!(v >= 1, "a Beneš network needs at least 2 wires");
+    2 * v - 1
+}
+
+/// Compute switch settings realizing `perm` on a Beneš network with
+/// `perm.len() = 2^v` wires: after applying all layers to an input vector
+/// `in`, the output satisfies `out[j] = in[perm[j]]`.
+///
+/// Returns one `Vec<bool>` per layer, indexed by wire; only the entries at
+/// upper wires (bit `k_ℓ` clear) are meaningful, the rest stay `false`.
+///
+/// # Panics
+///
+/// Panics when `perm.len()` is not a power of two `≥ 2` or `perm` is not a
+/// permutation of `0..perm.len()`; the caller (the witness builder)
+/// guarantees both.
+pub(crate) fn route(perm: &[usize]) -> Vec<Vec<bool>> {
+    let n = perm.len();
+    assert!(n >= 2 && n.is_power_of_two(), "wire count must be 2^v ≥ 2");
+    let v = n.trailing_zeros() as usize;
+    {
+        let mut seen = vec![false; n];
+        for &p in perm {
+            assert!(p < n && !seen[p], "input is not a permutation");
+            seen[p] = true;
+        }
+    }
+    let mut layers = vec![vec![false; n]; num_layers(v)];
+    route_block(perm, 0, 0, v, &mut layers);
+    layers
+}
+
+/// Route one recursion block.
+///
+/// * `perm`: block-relative permutation (`out[j] = in[perm[j]]` within the
+///   block).
+/// * `base`: first wire of the block in absolute wire indices.
+/// * `depth`: recursion depth; the block's entry layer is layer `depth` and
+///   its exit layer is layer `2v - 2 - depth`.
+/// * `v`: overall network size exponent.
+fn route_block(perm: &[usize], base: usize, depth: usize, v: usize, layers: &mut [Vec<bool>]) {
+    let m = perm.len();
+    debug_assert!(m.is_power_of_two() && m >= 2);
+    if m == 2 {
+        // Base case: the middle layer (`k = 0`) with a single switch.
+        let middle = v - 1;
+        debug_assert_eq!(depth, middle, "middle block at wrong depth");
+        layers[middle][base] = perm[0] == 1;
+        return;
+    }
+    let h = m / 2;
+
+    // 2-color the block inputs: color 0 routes through the top sub-network,
+    // color 1 through the bottom. Constraints: entry pair mates (i, i+h)
+    // get different colors, and exit pair mates (perm[j], perm[j+h]) get
+    // different colors. The constraint graph is 2-regular (every input has
+    // exactly one entry mate and one exit mate), i.e. a disjoint union of
+    // even cycles, so greedy alternating walks 2-color it.
+    let mut inv = vec![0usize; m];
+    for (j, &i) in perm.iter().enumerate() {
+        inv[i] = j;
+    }
+    let entry_mate = |i: usize| (i + h) % m;
+    // The exit mate of input i: the input delivered to the exit-pair
+    // partner of i's destination.
+    let exit_mate = |i: usize| perm[(inv[i] + h) % m];
+
+    let mut color = vec![u8::MAX; m];
+    for start in 0..m {
+        if color[start] != u8::MAX {
+            continue;
+        }
+        // Walk the cycle through `start`, alternating colors and edge kinds
+        // (entry mate must differ, exit mate must differ).
+        let mut i = start;
+        let mut c = 0u8;
+        let mut via_entry = true;
+        loop {
+            color[i] = c;
+            let next = if via_entry {
+                entry_mate(i)
+            } else {
+                exit_mate(i)
+            };
+            via_entry = !via_entry;
+            c ^= 1;
+            if next == start {
+                break;
+            }
+            debug_assert_eq!(color[next], u8::MAX, "coloring conflict");
+            i = next;
+        }
+    }
+
+    // Entry layer: upper wire a holds input a; switch bit 1 sends it to
+    // the bottom sub-network (position a + h).
+    let entry_layer = depth;
+    for a in 0..h {
+        layers[entry_layer][base + a] = color[a] == 1;
+        debug_assert_ne!(color[a], color[a + h], "entry mates share a color");
+    }
+
+    // Exit layer: output j takes the bottom sub-network's wire j exactly
+    // when its source input was colored bottom.
+    let exit_layer = 2 * v - 2 - depth;
+    for j in 0..h {
+        layers[exit_layer][base + j] = color[perm[j]] == 1;
+        debug_assert_ne!(
+            color[perm[j]],
+            color[perm[j + h]],
+            "exit mates share a color"
+        );
+    }
+
+    // Sub-permutations. Input i sits at sub-network position `i mod h` of
+    // the sub-network chosen by its color; output j is fed from sub-network
+    // position `j` (of the sub-network chosen by color[perm[j]]).
+    let mut perm_top = vec![0usize; h];
+    let mut perm_bot = vec![0usize; h];
+    for j in 0..h {
+        let (i0, i1) = (perm[j], perm[j + h]);
+        let (top_src, bot_src) = if color[i0] == 0 { (i0, i1) } else { (i1, i0) };
+        perm_top[j] = top_src % h;
+        perm_bot[j] = bot_src % h;
+    }
+    route_block(&perm_top, base, depth + 1, v, layers);
+    route_block(&perm_bot, base + h, depth + 1, v, layers);
+}
+
+/// Apply one network layer to a state vector, in place.
+///
+/// Generic over the wire payload so the witness builder can push whole
+/// limb-decomposed records through the network.
+pub(crate) fn apply_layer<T: Clone>(state: &mut [T], v: usize, layer: usize, bits: &[bool]) {
+    let n = state.len();
+    debug_assert_eq!(n, 1usize << v);
+    debug_assert_eq!(bits.len(), n);
+    let stride = 1usize << stride_bit(v, layer);
+    for (i, &bit) in bits.iter().enumerate() {
+        if i & stride == 0 && bit {
+            state.swap(i, i + stride);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use rand::{seq::SliceRandom, thread_rng};
+
+    /// Simulate the full network on the identity input and return the
+    /// output vector; `out[j]` must equal `perm[j]`.
+    fn simulate(perm: &[usize]) -> Vec<usize> {
+        let n = perm.len();
+        let v = n.trailing_zeros() as usize;
+        let layers = route(perm);
+        let mut state: Vec<usize> = (0..n).collect();
+        for (layer, bits) in layers.iter().enumerate() {
+            apply_layer(&mut state, v, layer, bits);
+        }
+        state
+    }
+
+    fn check(perm: &[usize]) {
+        assert_eq!(simulate(perm), perm, "network does not realize {perm:?}");
+    }
+
+    #[test]
+    fn test_v1_both_permutations() {
+        check(&[0, 1]);
+        check(&[1, 0]);
+    }
+
+    #[test]
+    fn test_v2_all_permutations() {
+        // All 24 permutations of 4 wires.
+        let mut perm = [0usize, 1, 2, 3];
+        permute_all(&mut perm, 0);
+    }
+
+    fn permute_all(perm: &mut [usize; 4], k: usize) {
+        if k == 4 {
+            check(perm);
+            return;
+        }
+        for i in k..4 {
+            perm.swap(k, i);
+            permute_all(perm, k + 1);
+            perm.swap(k, i);
+        }
+    }
+
+    #[test]
+    fn test_identity_and_reversal() {
+        for v in 1..=8 {
+            let n = 1usize << v;
+            let identity: Vec<usize> = (0..n).collect();
+            let reversal: Vec<usize> = (0..n).rev().collect();
+            check(&identity);
+            check(&reversal);
+        }
+    }
+
+    #[test]
+    fn test_random_permutations() {
+        let mut rng = thread_rng();
+        for v in 1..=8 {
+            let n = 1usize << v;
+            for _ in 0..20 {
+                let mut perm: Vec<usize> = (0..n).collect();
+                perm.shuffle(&mut rng);
+                check(&perm);
+            }
+        }
+    }
+
+    #[test]
+    fn test_rotations() {
+        // Cyclic shifts exercise long constraint-graph cycles.
+        for v in 1..=7 {
+            let n = 1usize << v;
+            for s in 0..n {
+                let perm: Vec<usize> = (0..n).map(|j| (j + s) % n).collect();
+                check(&perm);
+            }
+        }
+    }
+
+    #[test]
+    fn test_switch_bits_only_on_upper_wires() {
+        let mut rng = thread_rng();
+        let v = 5;
+        let n = 1usize << v;
+        let mut perm: Vec<usize> = (0..n).collect();
+        perm.shuffle(&mut rng);
+        let layers = route(&perm);
+        assert_eq!(layers.len(), num_layers(v));
+        for (layer, bits) in layers.iter().enumerate() {
+            let stride = 1usize << stride_bit(v, layer);
+            for (i, &bit) in bits.iter().enumerate() {
+                if i & stride != 0 {
+                    assert!(!bit, "switch bit set on lower wire {i} of layer {layer}");
+                }
+            }
+        }
+    }
+}

--- a/zkmemory/src/zincplus/mod.rs
+++ b/zkmemory/src/zincplus/mod.rs
@@ -2,22 +2,35 @@
 //! proof system (feature `zinc`).
 //!
 //! This module is an *optional, alternative* proof-system backend for the
-//! same statement family as the Halo2 circuits in [`crate::constraints`]:
-//! that a memory trace sorted by `(address, time_log)` is consistent (every
-//! read returns the last value written to that address). It follows the
-//! multi-backend layout of [`crate::nova`] and [`crate::supernova`] and is
-//! selectable next to Halo2 through [`crate::backend`].
+//! same statement as the composed Halo2 circuit in [`crate::constraints`]:
+//!
+//! 1. the *original* (time-ordered) trace starts at `time_log = 0` and its
+//!    `time_log`s strictly increase,
+//! 2. the trace sorted by `(address, time_log)` is memory-consistent (every
+//!    read returns the last value written to that address), and
+//! 3. the sorted trace is a permutation of the original trace.
+//!
+//! Zinc+ has no permutation/lookup argument, so sub-statement 3 is enforced
+//! **deterministically** with a Beneš switching network inside the AIR (see
+//! [`uair`] and [`benes`]) instead of a randomized shuffle argument. The
+//! module follows the multi-backend layout of [`crate::nova`] and
+//! [`crate::supernova`] and is selectable next to Halo2 through
+//! [`crate::backend`].
 //!
 //! # Quick start
 //!
 //! ```ignore
 //! use zkmemory::zincplus::{prove_memory_consistency, verify_memory_consistency};
 //!
-//! let trace = machine.trace(); // Vec<TraceRecord<B256, B256, 32, 32>>
+//! let trace = machine.trace(); // Vec<TraceRecord<B256, B256, 32, 32>>, time-ordered
 //! let proof = prove_memory_consistency(&trace)?;
 //! verify_memory_consistency(&proof)?;
 //! let bytes = proof.to_bytes()?; // transferable, succinct proof
 //! ```
+//!
+//! The input trace must be in execution order with `time_log`s starting at
+//! `0` and strictly increasing — the same contract the Halo2
+//! `OriginalMemoryCircuit` enforces.
 //!
 //! # Security status — read before use
 //!
@@ -25,14 +38,12 @@
 //!   zero-knowledge**: proofs are succinct but do **not** hide the witness.
 //! * Upstream Zinc+ is unaudited research software; this integration pins
 //!   one reviewed git revision.
-//! * Zinc+ currently lacks a permutation/lookup argument, so — unlike the
-//!   Halo2 [`crate::constraints`] circuit — the link between the sorted
-//!   trace and the original time-ordered trace is *not* enforced in-SNARK.
 //!
-//! The full discussion, including the migration plan for when upstream
-//! gains zero-knowledge and permutation support, lives in
+//! The full discussion lives in
 //! [`src/zincplus/README.md`](https://github.com/orochi-network/orochimaru/blob/main/zkmemory/src/zincplus/README.md).
 
+/// Prover-side Beneš-network routing for the permutation argument.
+pub(crate) mod benes;
 /// Prover / verifier entry points, proof and error types.
 pub(crate) mod prover;
 /// Concrete Zinc+ protocol type parameters (field, codes, widths).

--- a/zkmemory/src/zincplus/prover.rs
+++ b/zkmemory/src/zincplus/prover.rs
@@ -1,15 +1,23 @@
 //! Prover / verifier entry points of the Zinc+ memory-consistency backend.
 //!
-//! [`prove_memory_consistency`] takes the execution trace produced by an
-//! abstract machine ([`crate::machine::AbstractMachine::trace`]), sorts it by
-//! `(address, time_log)`, builds the UAIR witness and runs the Zinc+ prover.
-//! [`verify_memory_consistency`] re-derives the (transparent) commitment
-//! parameters and the public columns, then runs the Zinc+ verifier.
+//! [`prove_memory_consistency`] takes the *time-ordered* execution trace
+//! produced by an abstract machine ([`crate::machine::AbstractMachine::trace`]),
+//! validates the original-trace input contract (`time_log`s start at zero
+//! and strictly increase), sorts it by `(address, time_log)`, builds the
+//! UAIR witness — including the Beneš permutation network linking the two
+//! orderings — and runs the Zinc+ prover. [`verify_memory_consistency`]
+//! re-derives the (transparent) commitment parameters and the public
+//! columns, then runs the Zinc+ verifier.
 //!
 //! Zinc+ has no trusted setup and the prover is deterministic: all
 //! challenges, including the random prime-field modulus, are derived from
 //! the Blake3 Fiat-Shamir transcript after the witness commitments and the
 //! public columns are absorbed.
+//!
+//! The UAIR type is const-generic over the trace-size exponent (a
+//! [`zinc_uair::UairSignature`] is static per type while the permutation
+//! network's shape depends on the trace size), so proving and verification
+//! dispatch over the supported `num_vars` range via [`with_const_num_vars`].
 
 extern crate alloc;
 use alloc::{
@@ -20,7 +28,11 @@ use alloc::{
 use core::fmt;
 
 use zinc_protocol::{Proof, ZincPlusPiop};
-use zinc_uair::{ideal::DegreeOneIdeal, ideal_collector::IdealOrZero, Uair, UairTrace};
+use zinc_uair::{
+    ideal::{DegreeOneIdeal, ImpossibleIdeal},
+    ideal_collector::IdealOrZero,
+    UairTrace,
+};
 use zinc_utils::CHECKED;
 use zip_plus::pcs_transcript::PcsProverTranscript;
 
@@ -28,30 +40,77 @@ use crate::{base::B256, machine::TraceRecord};
 
 use super::{
     types::{setup_params, MemoryZincTypes, ZInt, D, F, QUARTER_D},
-    uair::{build_uair_trace, is_first_column, MemoryConsistencyUair, MAX_NUM_VARS, MIN_NUM_VARS},
+    uair::{
+        build_uair_trace, public_int_columns, MemoryConsistencyUair, MAX_NUM_VARS, MIN_NUM_VARS,
+    },
 };
 
-/// The fully-instantiated Zinc+ PIOP driving this backend.
-type MemoryPiop = ZincPlusPiop<MemoryZincTypes, MemoryConsistencyUair, F, D, QUARTER_D>;
+/// The fully-instantiated Zinc+ PIOP driving this backend, for traces of
+/// `2^V` padded rows.
+type MemoryPiop<const V: usize> =
+    ZincPlusPiop<MemoryZincTypes, MemoryConsistencyUair<V>, F, D, QUARTER_D>;
+
+/// Dispatch a macro over every supported `num_vars` as a const generic.
+///
+/// The body macro is invoked with a `usize` literal, so `$body!(N)` can name
+/// `MemoryPiop::<N>`. Keep the arms in sync with [`MIN_NUM_VARS`] and
+/// [`MAX_NUM_VARS`].
+macro_rules! with_const_num_vars {
+    ($num_vars:expr, $body:ident) => {
+        match $num_vars {
+            3 => $body!(3),
+            4 => $body!(4),
+            5 => $body!(5),
+            6 => $body!(6),
+            7 => $body!(7),
+            8 => $body!(8),
+            9 => $body!(9),
+            10 => $body!(10),
+            11 => $body!(11),
+            12 => $body!(12),
+            13 => $body!(13),
+            14 => $body!(14),
+            15 => $body!(15),
+            16 => $body!(16),
+            other => unreachable!(
+                "num_vars {other} was validated to lie in [{MIN_NUM_VARS}, {MAX_NUM_VARS}]"
+            ),
+        }
+    };
+}
 
 /// Errors of the Zinc+ memory-consistency backend.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ZincMemoryError {
     /// The execution trace is empty; there is nothing to prove.
     EmptyTrace,
-    /// The execution trace does not fit in `2^MAX_NUM_VARS - 1` rows.
-    TraceTooLong,
-    /// Two trace records share the same `(address, time_log)` pair. Traces
+    /// The first record's `time_log` is not zero. Like the Halo2
+    /// `OriginalMemoryCircuit`, the original trace must start at time zero.
+    FirstTimeNonZero {
+        /// The offending first `time_log`.
+        time_log: u64,
+    },
+    /// Two consecutive trace records share the same `time_log`. Traces
     /// produced by the abstract machine have globally unique `time_log`s.
     DuplicatedAccess {
         /// The duplicated `time_log`.
         time_log: u64,
     },
+    /// A record's `time_log` is smaller than its predecessor's. Like the
+    /// Halo2 `OriginalMemoryCircuit`, the original trace must be given in
+    /// execution order with strictly increasing `time_log`s.
+    TimeNotIncreasing {
+        /// The offending (decreased) `time_log`.
+        time_log: u64,
+    },
+    /// The execution trace does not fit in `2^MAX_NUM_VARS - 1` rows.
+    TraceTooLong,
     /// Padding the trace to a power of two would overflow the `u64` time
     /// domain.
     TimeLogOverflow,
-    /// Internal invariant violation: the sorted trace was not strictly
-    /// increasing. This indicates a bug rather than a bad input.
+    /// Internal invariant violation in the witness builder (the sorted
+    /// trace or the routed permutation network disagreed with the input).
+    /// This indicates a bug rather than a bad input.
     UnsortedTrace,
     /// The serialized proof is malformed.
     MalformedProof(String),
@@ -66,20 +125,28 @@ impl fmt::Display for ZincMemoryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyTrace => write!(f, "the execution trace is empty"),
+            Self::FirstTimeNonZero { time_log } => write!(
+                f,
+                "the original trace must start at time_log 0, got {time_log}"
+            ),
+            Self::DuplicatedAccess { time_log } => {
+                write!(f, "two trace records share time_log {time_log}")
+            }
+            Self::TimeNotIncreasing { time_log } => write!(
+                f,
+                "the original trace's time_logs must strictly increase; \
+                 time_log {time_log} decreases"
+            ),
             Self::TraceTooLong => {
                 write!(
                     f,
                     "the execution trace exceeds 2^{MAX_NUM_VARS} - 1 records"
                 )
             }
-            Self::DuplicatedAccess { time_log } => write!(
-                f,
-                "two trace records share the same (address, time_log = {time_log})"
-            ),
             Self::TimeLogOverflow => {
                 write!(f, "padding the trace would overflow the u64 time domain")
             }
-            Self::UnsortedTrace => write!(f, "internal error: sorted trace is not increasing"),
+            Self::UnsortedTrace => write!(f, "internal error: witness builder invariant violated"),
             Self::MalformedProof(msg) => write!(f, "malformed proof: {msg}"),
             Self::Prover(msg) => write!(f, "Zinc+ prover error: {msg}"),
             Self::Verifier(msg) => write!(f, "Zinc+ verification failed: {msg}"),
@@ -89,11 +156,13 @@ impl fmt::Display for ZincMemoryError {
 
 /// A Zinc+ memory-consistency proof.
 ///
-/// The proof attests that the prover knows a trace of `2^num_vars - 1` rows
-/// (the actual records followed by benign padding rows) that is sorted by
-/// `(address, time_log)` and memory-consistent — see
-/// [`super::uair::MemoryConsistencyUair`] for the exact relation and
-/// `src/zincplus/README.md` for what this does and does not imply.
+/// The proof attests that the prover knows a time-ordered execution trace
+/// of `2^num_vars - 1` rows (the actual records followed by benign padding
+/// rows) whose `time_log`s start at zero and strictly increase, together
+/// with its `(address, time_log)`-sorted permutation, and that the sorted
+/// ordering is memory-consistent — the same statement as the composed Halo2
+/// `MemoryConsistencyCircuit`. See [`super::uair::MemoryConsistencyUair`]
+/// for the exact relation.
 ///
 /// The proof is *succinct* and *transparent* but — with the current
 /// upstream Zinc+ — **not zero-knowledge**: assume the trace can be
@@ -161,36 +230,55 @@ impl ZincMemoryProof {
 /// system.
 ///
 /// The input is the *time-ordered* trace exactly as returned by
-/// [`crate::machine::AbstractMachine::trace`]; sorting by
-/// `(address, time_log)`, limb decomposition and padding happen internally.
-/// An *inconsistent* trace (e.g. a read returning a stale value) makes the
-/// witness violate the UAIR constraints and surfaces as
-/// [`ZincMemoryError::Prover`].
+/// [`crate::machine::AbstractMachine::trace`] and must satisfy the
+/// original-trace contract of the Halo2 `OriginalMemoryCircuit`:
+/// `time_log[0] = 0` and strictly increasing `time_log`s (gaps are
+/// allowed). Sorting by `(address, time_log)`, limb decomposition, padding
+/// and the permutation-network routing happen internally. An *inconsistent*
+/// trace (e.g. a read returning a stale value) makes the witness violate
+/// the UAIR constraints and surfaces as [`ZincMemoryError::Prover`].
 ///
 /// # Errors
 ///
-/// See [`ZincMemoryError`]; structurally invalid traces (empty, duplicated
-/// `(address, time_log)`, too long) are rejected before proving starts.
+/// See [`ZincMemoryError`]; structurally invalid traces (empty, wrong time
+/// ordering, too long) are rejected before proving starts.
 pub fn prove_memory_consistency(
     trace: &[TraceRecord<B256, B256, 32, 32>],
 ) -> Result<ZincMemoryProof, ZincMemoryError> {
     let (uair_trace, num_vars) = build_uair_trace(trace)?;
+    prove_from_uair_trace(&uair_trace, num_vars)
+}
+
+/// Run the Zinc+ prover on an already-built UAIR witness.
+///
+/// Split out of [`prove_memory_consistency`] so soundness tests can tamper
+/// with individual witness columns before proving.
+pub(crate) fn prove_from_uair_trace(
+    uair_trace: &UairTrace<'static, ZInt, ZInt, D, D>,
+    num_vars: usize,
+) -> Result<ZincMemoryProof, ZincMemoryError> {
     let params = setup_params(num_vars);
-    let proof = MemoryPiop::prove::<false, CHECKED>(
-        &params,
-        &uair_trace,
-        num_vars,
-        zinc_protocol::project_scalar_fn,
-    )
-    .map_err(|e| ZincMemoryError::Prover(e.to_string()))?;
+    macro_rules! run_prove {
+        ($v:literal) => {
+            MemoryPiop::<$v>::prove::<false, CHECKED>(
+                &params,
+                uair_trace,
+                num_vars,
+                zinc_protocol::project_scalar_fn,
+            )
+        };
+    }
+    let proof = with_const_num_vars!(num_vars, run_prove)
+        .map_err(|e| ZincMemoryError::Prover(e.to_string()))?;
     Ok(ZincMemoryProof { proof, num_vars })
 }
 
 /// Verify a Zinc+ memory-consistency proof.
 ///
 /// The verifier re-derives the transparent commitment parameters and the
-/// public `is_first` column (`[1, 0, 0, ...]`) itself, so a proof is
-/// accepted only for the exact public inputs this backend defines.
+/// public columns (`is_first` and the network's `upper_k` bit indicators)
+/// itself, so a proof is accepted only for the exact public inputs this
+/// backend defines.
 ///
 /// # Errors
 ///
@@ -206,23 +294,27 @@ pub fn verify_memory_consistency(proof: &ZincMemoryProof) -> Result<(), ZincMemo
     let public_trace: UairTrace<'static, ZInt, ZInt, D, D> = UairTrace {
         binary_poly: Vec::new().into(),
         arbitrary_poly: Vec::new().into(),
-        int: alloc::vec![is_first_column(1usize << num_vars)].into(),
+        int: public_int_columns(num_vars).into(),
     };
-    MemoryPiop::verify::<_, CHECKED>(
-        &params,
-        proof.proof.clone(),
-        &public_trace,
-        num_vars,
-        zinc_protocol::project_scalar_fn,
-        project_ideal,
-        project_fq_ideal,
-    )
-    .map_err(|e| ZincMemoryError::Verifier(e.to_string()))
+    macro_rules! run_verify {
+        ($v:literal) => {
+            MemoryPiop::<$v>::verify::<_, CHECKED>(
+                &params,
+                proof.proof.clone(),
+                &public_trace,
+                num_vars,
+                zinc_protocol::project_scalar_fn,
+                project_ideal,
+                project_fq_ideal,
+            )
+        };
+    }
+    with_const_num_vars!(num_vars, run_verify).map_err(|e| ZincMemoryError::Verifier(e.to_string()))
 }
 
 /// Project the UAIR's `Z[X]` ideals into the sampled prime field.
 fn project_ideal(
-    ideal: &IdealOrZero<<MemoryConsistencyUair as Uair>::Ideal>,
+    ideal: &IdealOrZero<DegreeOneIdeal<ZInt>>,
     field_cfg: &<F as crypto_primitives::HasPrimeFieldConfig>::Config,
 ) -> IdealOrZero<DegreeOneIdeal<F>> {
     ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg))
@@ -231,7 +323,7 @@ fn project_ideal(
 /// The memory-consistency UAIR declares no `F_q[X]` prime families, so this
 /// projection can never be invoked at runtime.
 fn project_fq_ideal(
-    _ideal: &IdealOrZero<<MemoryConsistencyUair as Uair>::FqIdeal>,
+    _ideal: &IdealOrZero<ImpossibleIdeal>,
     _field_cfg: &<F as crypto_primitives::HasPrimeFieldConfig>::Config,
 ) -> IdealOrZero<DegreeOneIdeal<F>> {
     unreachable!("the memory-consistency UAIR has no F_q[X] constraints")

--- a/zkmemory/src/zincplus/testcases.rs
+++ b/zkmemory/src/zincplus/testcases.rs
@@ -8,15 +8,35 @@
 //! rejects; each negative test therefore accepts *either* a proving failure
 //! *or* a verification failure, and only ever passes when the inconsistency
 //! is caught.
+//!
+//! On top of the trace-level cases, the `tamper_*` tests attack individual
+//! *witness columns* directly (through
+//! [`super::prover::prove_from_uair_trace`]): they build an honest witness
+//! and then corrupt exactly one cell of the permutation network, the
+//! original trace, or the sorted trace, proving that each sub-statement of
+//! the composed circuit — sorted consistency, original-trace time ordering
+//! and the permutation link — is live.
 
 extern crate alloc;
 extern crate std;
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
+
+use zinc_poly::univariate::binary::BinaryPoly;
+use zinc_uair::UairTrace;
 
 use crate::{
     base::B256,
     machine::{AbstractTraceRecord, MemoryInstruction, TraceRecord},
-    zincplus::{prove_memory_consistency, verify_memory_consistency, ZincMemoryError},
+    zincplus::{
+        prove_memory_consistency,
+        prover::prove_from_uair_trace,
+        types::{ZInt, D},
+        uair::{
+            build_uair_trace, build_uair_trace_any_start, NetLayout, PL_INSTR, PL_STACK_DEPTH,
+            PL_VALUE,
+        },
+        verify_memory_consistency, ZincMemoryError,
+    },
 };
 
 /// Shorthand for building one trace record.
@@ -79,6 +99,31 @@ fn test_single_write_trace() {
 }
 
 #[test]
+fn test_time_gaps_accepted() {
+    // The original-trace contract requires strictly increasing time_logs
+    // starting at 0 but allows gaps, exactly like the Halo2
+    // `OriginalMemoryCircuit`.
+    let trace = alloc::vec![
+        record(0, MemoryInstruction::Write, 0x0, 7),
+        record(5, MemoryInstruction::Read, 0x0, 7),
+        record(1000, MemoryInstruction::Write, 0x20, 9),
+        record((1 << 33) + 1, MemoryInstruction::Read, 0x20, 9),
+    ];
+    assert_accepted(&trace);
+}
+
+#[test]
+fn test_nonzero_stack_depth_accepted() {
+    // stack_depth rides the permutation network as payload; nonzero values
+    // must round-trip.
+    let trace = alloc::vec![
+        TraceRecord::new(0, 3, MemoryInstruction::Write, B256::from(0), B256::from(1)),
+        TraceRecord::new(1, 9, MemoryInstruction::Read, B256::from(0), B256::from(1)),
+    ];
+    assert_accepted(&trace);
+}
+
+#[test]
 fn test_wide_addresses_and_values() {
     // Addresses/values spanning the high 32-bit limbs, so the lexicographic
     // comparison must fall through several equal limbs before deciding.
@@ -100,16 +145,19 @@ fn test_wide_addresses_and_values() {
 #[test]
 fn test_power_of_two_length_trace() {
     // A trace whose length is already a power of two still gets one extra
-    // padding row (the protocol-exempt last row must never hold a record).
-    let mut trace = consistent_trace();
-    trace.truncate(8);
+    // padding row (the protocol-exempt last row must never hold a record),
+    // pushing it to the next trace size (16 rows, 7 network layers).
+    let trace = consistent_trace();
     assert_eq!(trace.len(), 8);
-    assert_accepted(&trace);
+    let proof = prove_memory_consistency(&trace).expect("proving succeeds");
+    assert_eq!(proof.num_vars(), 4);
+    verify_memory_consistency(&proof).expect("verification succeeds");
 }
 
 #[test]
 fn test_proof_serialization_roundtrip() {
-    let proof = prove_memory_consistency(&consistent_trace()).expect("proving succeeds");
+    let trace = &consistent_trace()[..7];
+    let proof = prove_memory_consistency(trace).expect("proving succeeds");
     let bytes = proof.to_bytes().expect("serialization succeeds");
     let restored =
         crate::zincplus::ZincMemoryProof::from_bytes(&bytes).expect("deserialization succeeds");
@@ -119,7 +167,7 @@ fn test_proof_serialization_roundtrip() {
 
 #[test]
 fn test_tampered_proof_rejected() {
-    let proof = prove_memory_consistency(&consistent_trace()).expect("proving succeeds");
+    let proof = prove_memory_consistency(&consistent_trace()[..7]).expect("proving succeeds");
     let bytes = proof.to_bytes().expect("serialization succeeds");
     // Flip one byte somewhere inside the proof body (past the num_vars
     // header) and require rejection.
@@ -188,8 +236,31 @@ fn test_empty_trace_rejected() {
 }
 
 #[test]
+fn test_first_time_nonzero_rejected() {
+    // The original trace must start at time_log 0 (Halo2
+    // `OriginalMemoryCircuit` parity).
+    assert_eq!(
+        prove_memory_consistency(&[record(1, MemoryInstruction::Write, 0x0, 1)]),
+        Err(ZincMemoryError::FirstTimeNonZero { time_log: 1 })
+    );
+}
+
+#[test]
+fn test_time_decreasing_rejected() {
+    let trace = alloc::vec![
+        record(0, MemoryInstruction::Write, 0x0, 1),
+        record(2, MemoryInstruction::Write, 0x20, 2),
+        record(1, MemoryInstruction::Write, 0x40, 3),
+    ];
+    assert_eq!(
+        prove_memory_consistency(&trace),
+        Err(ZincMemoryError::TimeNotIncreasing { time_log: 1 })
+    );
+}
+
+#[test]
 fn test_duplicated_access_rejected() {
-    // Two records with identical (address, time_log).
+    // Two records with the same time_log at the same address.
     let trace = alloc::vec![
         record(0, MemoryInstruction::Write, 0x0, 1),
         record(0, MemoryInstruction::Read, 0x0, 1),
@@ -201,9 +272,26 @@ fn test_duplicated_access_rejected() {
 }
 
 #[test]
+fn test_same_time_different_address_rejected() {
+    // Halo2's original circuit demands *strictly* increasing time_logs, so
+    // a shared time_log is rejected even across different addresses.
+    let trace = alloc::vec![
+        record(0, MemoryInstruction::Write, 0x0, 1),
+        record(0, MemoryInstruction::Write, 0x20, 2),
+    ];
+    assert_eq!(
+        prove_memory_consistency(&trace),
+        Err(ZincMemoryError::DuplicatedAccess { time_log: 0 })
+    );
+}
+
+#[test]
 fn test_time_log_overflow_rejected() {
     // The padding rows would need time_logs beyond u64::MAX.
-    let trace = alloc::vec![record(u64::MAX, MemoryInstruction::Write, 0x0, 1)];
+    let trace = alloc::vec![
+        record(0, MemoryInstruction::Write, 0x0, 1),
+        record(u64::MAX, MemoryInstruction::Write, 0x20, 2),
+    ];
     assert_eq!(
         prove_memory_consistency(&trace),
         Err(ZincMemoryError::TimeLogOverflow)
@@ -212,8 +300,185 @@ fn test_time_log_overflow_rejected() {
 
 #[test]
 fn test_truncated_proof_rejected() {
-    let proof = prove_memory_consistency(&consistent_trace()).expect("proving succeeds");
+    let proof = prove_memory_consistency(&consistent_trace()[..7]).expect("proving succeeds");
     let bytes = proof.to_bytes().expect("serialization succeeds");
     assert!(crate::zincplus::ZincMemoryProof::from_bytes(&bytes[..bytes.len() / 2]).is_err());
     assert!(crate::zincplus::ZincMemoryProof::from_bytes(&[]).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Witness-tampering soundness tests: corrupt exactly one witness cell of an
+// otherwise honest witness and require rejection.
+// ---------------------------------------------------------------------------
+
+/// Build the honest witness for [`consistent_trace`] (7 records → 8 rows),
+/// apply `mutate`, run the real prover and require rejection at proving or
+/// verification time.
+fn assert_tampered_witness_rejected(
+    mutate: impl FnOnce(&mut UairTrace<'static, ZInt, ZInt, D, D>, &NetLayout),
+) {
+    let trace = consistent_trace();
+    let (mut uair_trace, num_vars) =
+        build_uair_trace(&trace[..7]).expect("the honest witness builds");
+    let layout = NetLayout::new(num_vars);
+    mutate(&mut uair_trace, &layout);
+    match prove_from_uair_trace(&uair_trace, num_vars) {
+        Err(ZincMemoryError::Prover(_)) => {}
+        Err(other) => panic!("unexpected error kind: {other}"),
+        Ok(proof) => assert!(
+            verify_memory_consistency(&proof).is_err(),
+            "a tampered witness slipped through both the prover and the verifier"
+        ),
+    }
+}
+
+/// Overwrite one binary-polynomial witness cell.
+fn set_bp_cell(
+    uair_trace: &mut UairTrace<'static, ZInt, ZInt, D, D>,
+    col: usize,
+    row: usize,
+    value: u32,
+) {
+    uair_trace.binary_poly.to_mut()[col].evaluations[row] = BinaryPoly::from(value);
+}
+
+#[test]
+fn test_tamper_original_trace_record_rejected() {
+    // Corrupt one value limb of one *original-trace* record (the network
+    // output side): the record multisets of the two orderings no longer
+    // match, so the final network layer's swap equations must fail. This is
+    // the permutation link at work — before it existed, the original-trace
+    // columns were not committed at all.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        let col = layout.state_col(layout.original_state(), PL_VALUE + 7);
+        set_bp_cell(uair_trace, col, 0, 0xdead_beef);
+    });
+}
+
+#[test]
+fn test_tamper_sorted_trace_record_rejected() {
+    // Corrupt one stack_depth limb of one *sorted-trace* record (the
+    // network input side). No sorted-consistency constraint reads
+    // stack_depth — only the permutation network binds it — so rejection
+    // proves the network covers the full record payload.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        let col = layout.state_col(0, PL_STACK_DEPTH + 1);
+        set_bp_cell(uair_trace, col, 2, 7);
+    });
+}
+
+#[test]
+fn test_tamper_interior_network_state_rejected() {
+    // Corrupt one cell of an interior routing state: the swap equations of
+    // the two adjacent layers cannot both hold. Flip the instruction bit so
+    // the tampered value is guaranteed to differ from the honest one.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        let col = layout.state_col(layout.num_layers / 2, PL_INSTR);
+        let cell = &mut uair_trace.binary_poly.to_mut()[col].evaluations[1];
+        let flipped = if *cell == BinaryPoly::from(1u32) {
+            0u32
+        } else {
+            1u32
+        };
+        *cell = BinaryPoly::from(flipped);
+    });
+}
+
+#[test]
+fn test_tamper_switch_bit_rejected() {
+    // Flip one switch bit without re-routing: the committed states no
+    // longer satisfy that switch's swap equations.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        let col = layout.int_switch; // layer 0; row 0 is an upper wire
+        let cell = &mut uair_trace.int.to_mut()[col].evaluations[0];
+        *cell = 1 - *cell;
+    });
+}
+
+#[test]
+fn test_tamper_switch_bit_non_boolean_rejected() {
+    // A non-boolean switch "mixes" the two records instead of swapping
+    // them; the masked booleanity constraint must reject it.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        let col = layout.int_switch + 1; // layer 1; row 0 is an upper wire
+        uair_trace.int.to_mut()[col].evaluations[0] = 2;
+    });
+}
+
+#[test]
+fn test_tamper_original_time_slack_rejected() {
+    // Corrupt the original-trace time slack: the strict-increase relation
+    // `o_hi·Δhi + o_lo·Δlo = 1 + r_O` must fail.
+    assert_tampered_witness_rejected(|uair_trace, layout| {
+        set_bp_cell(uair_trace, layout.bp_slack_original, 0, 41);
+    });
+}
+
+#[test]
+fn test_nonzero_start_time_rejected_in_circuit() {
+    // A trace whose time_logs are shifted by +1 yields a witness where
+    // *every* constraint holds except "the original trace starts at
+    // time_log 0" — proving that constraint is enforced in-circuit and not
+    // only by the input validation.
+    let shifted: Vec<TraceRecord<B256, B256, 32, 32>> = consistent_trace()[..7]
+        .iter()
+        .map(|r| {
+            TraceRecord::new(
+                r.time_log() + 1,
+                r.stack_depth(),
+                r.instruction(),
+                r.address(),
+                r.value(),
+            )
+        })
+        .collect();
+    // The public API refuses it outright...
+    assert_eq!(
+        prove_memory_consistency(&shifted),
+        Err(ZincMemoryError::FirstTimeNonZero { time_log: 1 })
+    );
+    // ...and so does the circuit itself when validation is bypassed.
+    let (uair_trace, num_vars) =
+        build_uair_trace_any_start(&shifted).expect("the shifted witness builds");
+    match prove_from_uair_trace(&uair_trace, num_vars) {
+        Err(ZincMemoryError::Prover(_)) => {}
+        Err(other) => panic!("unexpected error kind: {other}"),
+        Ok(proof) => assert!(
+            verify_memory_consistency(&proof).is_err(),
+            "a nonzero-start trace slipped through the circuit"
+        ),
+    }
+}
+
+#[test]
+fn test_honest_witness_still_proves_after_helper_roundtrip() {
+    // Guard for the tamper helpers themselves: an *unmodified* witness run
+    // through the same internal entry point must still prove and verify, so
+    // the tamper tests above cannot pass vacuously.
+    let (uair_trace, num_vars) =
+        build_uair_trace(&consistent_trace()[..7]).expect("the honest witness builds");
+    let proof = prove_from_uair_trace(&uair_trace, num_vars).expect("honest witness proves");
+    verify_memory_consistency(&proof).expect("honest proof verifies");
+}
+
+#[test]
+fn test_trace_too_long_rejected() {
+    // A trace beyond 2^MAX_NUM_VARS - 1 records must be rejected up front.
+    // Build the length check input cheaply: the length test fires before
+    // any witness work.
+    let too_long = 1usize << crate::zincplus::uair::MAX_NUM_VARS;
+    let trace: Vec<TraceRecord<B256, B256, 32, 32>> = (0..too_long as u64)
+        .map(|t| record(t, MemoryInstruction::Write, 0x0, 1))
+        .collect();
+    assert_eq!(
+        prove_memory_consistency(&trace),
+        Err(ZincMemoryError::TraceTooLong)
+    );
+}
+
+#[test]
+fn test_error_display_is_informative() {
+    // The user-facing error strings should carry the offending time_log.
+    let message = format!("{}", ZincMemoryError::FirstTimeNonZero { time_log: 42 });
+    assert!(message.contains("42"), "unhelpful message: {message}");
 }

--- a/zkmemory/src/zincplus/uair.rs
+++ b/zkmemory/src/zincplus/uair.rs
@@ -2,75 +2,128 @@
 //!
 //! # The statement
 //!
-//! The UAIR constrains a *sorted* memory trace: the execution trace re-ordered
-//! by `(address, time_log)`. Together the constraints enforce, for every pair
-//! of adjacent rows `i -> i+1` (rows `0 .. 2^num_vars - 1`, the final row is a
-//! protocol-level padding row exempted by Zinc+'s last-row selector):
+//! The UAIR proves the *composed* memory-consistency statement — the same
+//! statement as the Halo2 `MemoryConsistencyCircuit` in
+//! [`crate::constraints`], which combines three sub-circuits:
 //!
-//! 1. the very first access of the trace is a write,
-//! 2. every instruction is boolean (`0` = read, `1` = write),
-//! 3. `(address, time_log)` strictly increases row to row (lexicographically),
-//! 4. a read from an address returns the value of the previous access to the
-//!    same address,
-//! 5. the first access to every *new* address is a write.
+//! 1. **Original-trace consistency** (Halo2 `OriginalMemoryCircuit`): the
+//!    time-ordered execution trace `O` starts at `time_log = 0` and its
+//!    `time_log`s strictly increase row to row.
+//! 2. **Sorted-trace consistency** (Halo2 `SortedMemoryCircuit`): the trace
+//!    `S` obtained by sorting `O` by `(address, time_log)` is internally
+//!    consistent — the first access overall and the first access of every
+//!    new address are writes, instructions are boolean, `(address,
+//!    time_log)` strictly increases lexicographically, and every read
+//!    returns the value of the previous access to the same address.
+//! 3. **Permutation link** (Halo2 `PermutationCircuit`): `S` is a
+//!    permutation of `O`.
 //!
-//! These are exactly the constraints of the Halo2 `SortedMemoryCircuit` in
-//! [`crate::constraints`]. What this backend does **not** yet prove is the
-//! permutation link between the sorted trace and the original time-ordered
-//! trace — Zinc+ currently has no permutation/lookup argument. See
-//! `src/zincplus/README.md` for the exact security consequences.
+//! Both traces are witnesses and there are no public inputs beyond fixed
+//! selector patterns, matching the Halo2 composed circuit exactly.
+//!
+//! # The permutation argument: a Beneš network
+//!
+//! Zinc+ has no permutation/lookup argument and no verifier-randomness
+//! (RAP-style) columns, and every committed cell must be a small integer
+//! fixed *before* the random prime modulus is sampled — so the randomized
+//! grand-product argument used by PLONK's shuffle is not expressible.
+//! Instead the permutation is enforced **deterministically** with a Beneš
+//! switching network (the classic challenge-free technique for RAM
+//! checking in proof systems, cf. Pantry/Buffet/xJsnark):
+//!
+//! * every trace row is one network *wire*; the network has `2v - 1` layers
+//!   (`v` = `num_vars`, `2^v` rows) laid out horizontally as `2v` *state*
+//!   column groups of [`PAYLOAD_CELLS`] columns each — state `0` is `S`,
+//!   state `2v - 1` is `O`;
+//! * layer `ℓ` sits between states `ℓ` and `ℓ + 1` and pairs row `i` with
+//!   row `i + 2^{k_ℓ}` for every `i` whose bit `k_ℓ` is zero (see
+//!   [`super::benes`] for the stride schedule);
+//! * each pair is a 2×2 conditional swap controlled by one boolean switch
+//!   witness shared by all payload columns:
+//!   `out₁ = in₁ + s·(in₂ - in₁)` and `out₂ = in₂ - s·(in₂ - in₁)`,
+//!   anchored at the upper row and masked by the public indicator column
+//!   `upper_k` (`upper_k[i] = 1` iff bit `k` of `i` is zero);
+//! * the swap equations are *cell-exact* (coefficient-wise on the binary
+//!   polynomials), so each state is an exact permutation of the previous
+//!   one and `multiset(O) = multiset(S)` holds exactly — soundness never
+//!   depends on how the prover routes, only completeness does.
+//!
+//! The routed payload is the complete record — address, `time_log`,
+//! `stack_depth`, value and instruction limbs — so the permutation binds
+//! full records, like the Halo2 shuffle's random linear compression does.
 //!
 //! # Column layout
 //!
-//! Addresses and values are 256-bit integers and `time_log` is a `u64`; all
-//! are decomposed into 32-bit limbs held in *binary polynomial* columns
-//! (`BinaryPoly<32>`, one boolean coefficient per bit). Zinc+'s built-in
-//! booleanity argument guarantees every committed coefficient is a bit, so
-//! `limb(2)` (the polynomial evaluated at `X = 2`) is a canonical `u32`:
-//! range checks come for free and never need a lookup table.
+//! Addresses and values are 256-bit and `time_log` / `stack_depth` are
+//! `u64`; all are decomposed into 32-bit limbs held in *binary polynomial*
+//! columns (`BinaryPoly<32>`, one boolean coefficient per bit). Zinc+'s
+//! built-in booleanity argument guarantees every committed coefficient is
+//! a bit, so `limb(2)` (the polynomial evaluated at `X = 2`) is a canonical
+//! `u32`: range checks come for free and never need a lookup table. The
+//! instruction also lives in a binary-polynomial cell, pinned to a constant
+//! `0`/`1` polynomial by its booleanity constraint.
 //!
-//! Binary-polynomial columns (flat indices `0..19`):
+//! Binary-polynomial columns (flat indices):
 //!
 //! | index | content |
 //! |-------|---------|
-//! | `0..8`  | address limbs, most-significant first |
-//! | `8..10` | `time_log` limbs, most-significant first |
-//! | `10..18`| value limbs, most-significant first |
-//! | `18`    | `r`: slack of the strict lexicographic increase at `i -> i+1` |
+//! | `g·21 .. g·21+21` | network state `g` (`g = 0`: sorted trace `S`, `g = 2v-1`: original trace `O`); within a state: address limbs `0..8`, `time_log` limbs `8..10`, `stack_depth` limbs `10..12`, value limbs `12..20`, instruction `20` (most-significant limb first) |
+//! | `42v`   | `r_S`: slack of the strict lexicographic `(address, time_log)` increase of `S` |
+//! | `42v+1` | `r_O`: slack of the strict `time_log` increase of `O` |
 //!
 //! Integer columns (public columns precede witness columns):
 //!
 //! | index | content |
 //! |-------|---------|
-//! | `0` (public) | `is_first`: fixed pattern `[1, 0, 0, ...]` checked by the verifier |
-//! | `1`   | instruction (`1` = write, `0` = read) |
-//! | `2..12` | `s_0..s_9`: one-hot selector of the first differing limb of `(address, time)` at `i -> i+1` |
-//! | `12`  | `w = (s_8 + s_9) * (instr[i+1] - 1)`: helper keeping every constraint at degree <= 2 |
+//! | `0` (public) | `is_first`: fixed pattern `[1, 0, 0, ...]` |
+//! | `1..v+1` (public) | `upper_k`, `k = 0..v`: bit-`k`-is-zero indicator of the row index |
+//! | `v+1..v+11` | `s_0..s_9`: one-hot selector of the first differing limb of `S`'s `(address, time)` at `i -> i+1` |
+//! | `v+11` | `w = (s_8 + s_9) · (instr_S[i+1] - 1)`: degree-reduction helper |
+//! | `v+12`, `v+13` | `o_hi`, `o_lo`: one-hot selector of the first differing `time_log` limb of `O` at `i -> i+1` |
+//! | `v+14..3v+13` | one switch-bit column per network layer |
+//!
+//! All public columns are reconstructed by the verifier itself
+//! ([`public_int_columns`]) and absorbed into the Fiat-Shamir transcript
+//! before any challenge is drawn.
 //!
 //! # Constraint soundness sketch
 //!
-//! Write `L_0..L_9` for the lexicographic limb vector `address || time_log`
-//! of the current row, `L'_j` for the next row, and `d_j = L'_j - L_j`.
+//! *Sorted trace* (state `0`; write `L_0..L_9` for the lexicographic limb
+//! vector `address || time_log`, primes for the next row, `d_j = L'_j -
+//! L_j`):
 //!
 //! * `s_j` boolean and `sum_j s_j = 1` force exactly one selected position
-//!   `k`.
-//! * `(1 - e_j) * d_j = 0` with `e_j = s_0 + ... + s_j` forces `d_j = 0`
-//!   for every `j < k` (booleanity of the limbs makes "equal value" and
-//!   "equal bit pattern" coincide).
-//! * `sum_j s_j * d_j - 1 - r in (X - 2)` forces `d_k(2) = 1 + r(2)` with
-//!   `r(2)` a canonical `u32`, i.e. `1 <= d_k(2)`: the first differing limb
-//!   strictly increases, hence `(address, time)` strictly increases. A
-//!   dishonest choice of `k` (before or after the true first difference)
-//!   contradicts one of the two previous bullets.
-//! * `a_same = s_8 + s_9` is therefore `1` exactly when the first difference
-//!   lies in the time limbs, i.e. when both rows touch the same address.
-//! * `w = a_same * (instr' - 1)` is `-1` exactly for a *read at an unchanged
-//!   address* and `0` otherwise, so `w * (value'_j - value_j) = 0` pins each
-//!   read to the previous value, and `(1 - a_same) * (instr' - 1) = 0`
-//!   forces the first access of a new address to be a write.
+//!   `k`; `(1 - (s_0 + ... + s_j)) · d_j = 0` forces `d_j = 0` for `j < k`;
+//!   `sum_j s_j·d_j - 1 - r_S in (X - 2)` forces `d_k(2) = 1 + r_S(2)` with
+//!   `r_S(2)` a canonical `u32`, so `(address, time)` strictly increases.
+//! * `a_same = s_8 + s_9` is `1` exactly when adjacent rows touch the same
+//!   address; `w = a_same · (instr' - 1)` is `-1` exactly for a read at an
+//!   unchanged address, so `w · (value'_j - value_j) = 0` pins each read to
+//!   the previous value and `(1 - a_same) · (instr' - 1) = 0` forces the
+//!   first access of a new address to be a write. `is_first · (instr - 1) =
+//!   0` makes the very first access a write.
+//!
+//! *Original trace* (state `2v - 1`): `is_first` pins both `time_log` limbs
+//! of row 0 to zero; `o_hi`/`o_lo` are a one-hot selector with `(1 - o_hi)
+//! · (hi' - hi) = 0` and `o_hi·(hi' - hi) + o_lo·(lo' - lo) - 1 - r_O in (X
+//! - 2)`, which is exactly "the `u64` `time_log` strictly increases" —
+//! the same relation as Halo2's `GreaterThanConfig` on the original trace.
+//!
+//! *Network*: for every layer and every upper row, `upper_k` masks the
+//! boolean-switch swap equations described above. Rows partition into
+//! disjoint switch pairs per layer, so each state is a permutation of the
+//! previous one. Row `2^v - 1` (all index bits set) is never an anchor row
+//! of any switch, so Zinc+'s built-in last-row constraint exemption opens
+//! no hole in the network; the `S`/`O` transition constraints reaching the
+//! last row are anchored at row `2^v - 2`, which is not exempt.
+//!
+//! All per-row constraint expressions have coefficients that are tiny
+//! relative to the ~192-bit sampled prime `q`, so their vanishing mod `q`
+//! implies vanishing over the integers: the permutation and consistency
+//! statements hold exactly, not just probabilistically.
 
 extern crate alloc;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::BTreeMap, vec, vec::Vec};
 use core::cmp::Ordering;
 
 use zinc_poly::univariate::{binary::BinaryPoly, dense::DensePolynomial};
@@ -86,6 +139,7 @@ use crate::{
 };
 
 use super::{
+    benes,
     types::{Fmod, ZInt, D},
     ZincMemoryError,
 };
@@ -94,61 +148,224 @@ use super::{
 pub(crate) const NUM_ADDR_LIMBS: usize = 8;
 /// Number of 32-bit limbs of a `time_log`.
 pub(crate) const NUM_TIME_LIMBS: usize = 2;
+/// Number of 32-bit limbs of a `stack_depth`.
+pub(crate) const NUM_STACK_DEPTH_LIMBS: usize = 2;
 /// Number of 32-bit limbs of a value.
 pub(crate) const NUM_VALUE_LIMBS: usize = 8;
 /// Number of limbs compared lexicographically: `address || time_log`.
 pub(crate) const NUM_LEX_LIMBS: usize = NUM_ADDR_LIMBS + NUM_TIME_LIMBS;
 
-/// First binary-polynomial column of the address limbs.
-const BP_ADDR: usize = 0;
-/// First binary-polynomial column of the `time_log` limbs.
-const BP_TIME: usize = BP_ADDR + NUM_ADDR_LIMBS;
-/// First binary-polynomial column of the value limbs.
-const BP_VALUE: usize = BP_TIME + NUM_TIME_LIMBS;
-/// Binary-polynomial column of the lexicographic slack `r`.
-const BP_SLACK: usize = BP_VALUE + NUM_VALUE_LIMBS;
-/// Total number of binary-polynomial columns.
-pub(crate) const NUM_BP_COLS: usize = BP_SLACK + 1;
+/// Payload offset of the address limbs (also the start of the lex limbs).
+pub(crate) const PL_ADDR: usize = 0;
+/// Payload offset of the `time_log` limbs.
+pub(crate) const PL_TIME: usize = PL_ADDR + NUM_ADDR_LIMBS;
+/// Payload offset of the `stack_depth` limbs.
+pub(crate) const PL_STACK_DEPTH: usize = PL_TIME + NUM_TIME_LIMBS;
+/// Payload offset of the value limbs.
+pub(crate) const PL_VALUE: usize = PL_STACK_DEPTH + NUM_STACK_DEPTH_LIMBS;
+/// Payload offset of the instruction cell.
+pub(crate) const PL_INSTR: usize = PL_VALUE + NUM_VALUE_LIMBS;
+/// Number of binary-polynomial cells of one full record: the payload routed
+/// through every switch of the permutation network.
+pub(crate) const PAYLOAD_CELLS: usize = PL_INSTR + 1;
 
-/// Integer column of the public `is_first` indicator.
-const INT_IS_FIRST: usize = 0;
-/// Integer column of the instruction.
-const INT_INSTR: usize = 1;
-/// First integer column of the one-hot selectors `s_0..s_9`.
-const INT_S: usize = 2;
-/// Integer column of the degree-reduction helper `w`.
-const INT_W: usize = INT_S + NUM_LEX_LIMBS;
-/// Total number of integer columns.
-pub(crate) const NUM_INT_COLS: usize = INT_W + 1;
+/// Minimum trace size (`2^MIN_NUM_VARS` rows) accepted by the Zip+ codes.
+pub(crate) const MIN_NUM_VARS: usize = 3;
+/// Maximum trace size exponent accepted by [`build_uair_trace`] and by the
+/// verifier.
+///
+/// Bounded by practicality rather than protocol limits: the Beneš network
+/// adds `~21·(2v)` committed columns and the verifier pays `O(2^{v-1})`
+/// field operations per large-stride shifted column, so very large traces
+/// belong to a future lookup-based permutation argument (see
+/// `src/zincplus/README.md`).
+pub(crate) const MAX_NUM_VARS: usize = 16;
 
-/// Index of the (single) shifted integer column inside `down.int`:
-/// the next row's instruction.
-const DOWN_INT_INSTR: usize = 0;
+/// The column layout of the memory-consistency UAIR for a given trace size,
+/// shared by [`Uair::signature`], the constraint emission and the witness
+/// builder so all three can never disagree.
+pub(crate) struct NetLayout {
+    /// `log2` of the (padded) row count.
+    num_vars: usize,
+    /// Number of Beneš layers: `2·num_vars - 1`.
+    pub(crate) num_layers: usize,
+    /// Number of network states: `num_layers + 1`; state `0` is the sorted
+    /// trace, state `num_states - 1` the original trace.
+    num_states: usize,
+    /// Total binary-polynomial columns.
+    pub(crate) num_bp_cols: usize,
+    /// Total integer columns (public + witness).
+    pub(crate) num_int_cols: usize,
+    /// Leading integer columns that are public.
+    pub(crate) num_public_int_cols: usize,
+    /// Binary column of the sorted-trace lexicographic slack `r_S`.
+    pub(crate) bp_slack_sorted: usize,
+    /// Binary column of the original-trace time slack `r_O`.
+    pub(crate) bp_slack_original: usize,
+    /// Integer column of the public `is_first` indicator.
+    int_is_first: usize,
+    /// First of the `num_vars` public `upper_k` indicator columns.
+    int_upper: usize,
+    /// First of the [`NUM_LEX_LIMBS`] sorted-trace selector columns.
+    int_s: usize,
+    /// Integer column of the sorted-trace degree-reduction helper `w`.
+    int_w: usize,
+    /// Integer column of the original-trace high-limb selector `o_hi`.
+    int_time_hi_sel: usize,
+    /// Integer column of the original-trace low-limb selector `o_lo`.
+    int_time_lo_sel: usize,
+    /// First of the `num_layers` switch-bit columns.
+    pub(crate) int_switch: usize,
+    /// Every `(source_col, shift_amount)` pair, sorted; position `i` in this
+    /// list is index `i` of the down row's binary-polynomial slice.
+    shifts: Vec<(usize, usize)>,
+}
 
-/// The memory-consistency UAIR. See the module documentation for the full
-/// description of columns and constraints.
+impl NetLayout {
+    /// Build the layout for `2^num_vars` rows.
+    pub(crate) fn new(num_vars: usize) -> Self {
+        assert!(
+            (MIN_NUM_VARS..=MAX_NUM_VARS).contains(&num_vars),
+            "num_vars {num_vars} outside [{MIN_NUM_VARS}, {MAX_NUM_VARS}]"
+        );
+        let num_layers = benes::num_layers(num_vars);
+        let num_states = num_layers + 1;
+        let payload_cols = num_states * PAYLOAD_CELLS;
+        let bp_slack_sorted = payload_cols;
+        let bp_slack_original = payload_cols + 1;
+        let num_bp_cols = payload_cols + 2;
+
+        let int_is_first = 0;
+        let int_upper = 1;
+        let int_s = int_upper + num_vars;
+        let int_w = int_s + NUM_LEX_LIMBS;
+        let int_time_hi_sel = int_w + 1;
+        let int_time_lo_sel = int_time_hi_sel + 1;
+        let int_switch = int_time_lo_sel + 1;
+        let num_int_cols = int_switch + num_layers;
+        let num_public_int_cols = 1 + num_vars;
+
+        let mut layout = Self {
+            num_vars,
+            num_layers,
+            num_states,
+            num_bp_cols,
+            num_int_cols,
+            num_public_int_cols,
+            bp_slack_sorted,
+            bp_slack_original,
+            int_is_first,
+            int_upper,
+            int_s,
+            int_w,
+            int_time_hi_sel,
+            int_time_lo_sel,
+            int_switch,
+            shifts: Vec::new(),
+        };
+        layout.shifts = layout.build_shifts();
+        layout
+    }
+
+    /// The flat binary column of payload cell `p` of network state `g`.
+    pub(crate) fn state_col(&self, state: usize, payload: usize) -> usize {
+        debug_assert!(state < self.num_states && payload < PAYLOAD_CELLS);
+        state * PAYLOAD_CELLS + payload
+    }
+
+    /// Index of the original-trace state (the network output).
+    pub(crate) fn original_state(&self) -> usize {
+        self.num_states - 1
+    }
+
+    /// The row stride of network layer `layer`.
+    fn stride(&self, layer: usize) -> usize {
+        1usize << benes::stride_bit(self.num_vars, layer)
+    }
+
+    /// All `(source_col, shift_amount)` pairs, sorted by column then amount.
+    ///
+    /// * State `0` (the sorted trace) is consumed by layer `0` (stride
+    ///   `2^{v-1}`) and by the sorted-trace transition constraints (shift
+    ///   `1`, all payload cells except `stack_depth`, which no sorted-trace
+    ///   constraint reads).
+    /// * Interior state `g` is produced by layer `g - 1` and consumed by
+    ///   layer `g`; each needs the corresponding stride.
+    /// * The last state (the original trace) is produced by the final layer
+    ///   and its `time_log` limbs feed the shift-`1` time-ordering
+    ///   constraints.
+    fn build_shifts(&self) -> Vec<(usize, usize)> {
+        let mut shifts = Vec::new();
+        let last = self.original_state();
+        for state in 0..self.num_states {
+            for payload in 0..PAYLOAD_CELLS {
+                let col = self.state_col(state, payload);
+                let amounts: [Option<usize>; 2] = if state == 0 {
+                    let in_transitions = payload != PL_STACK_DEPTH && payload != PL_STACK_DEPTH + 1;
+                    [in_transitions.then_some(1), Some(self.stride(0))]
+                } else if state < last {
+                    let (a, b) = (self.stride(state - 1), self.stride(state));
+                    [Some(a.min(b)), Some(a.max(b))]
+                } else {
+                    let in_transitions = payload == PL_TIME || payload == PL_TIME + 1;
+                    [
+                        in_transitions.then_some(1),
+                        Some(self.stride(self.num_layers - 1)),
+                    ]
+                };
+                for amount in amounts.into_iter().flatten() {
+                    shifts.push((col, amount));
+                }
+            }
+        }
+        debug_assert!(
+            shifts.windows(2).all(|w| w[0] < w[1]),
+            "shift list must be strictly sorted"
+        );
+        shifts
+    }
+
+    /// The signature's [`ShiftSpec`] list, in down-row order.
+    fn shift_specs(&self) -> Vec<ShiftSpec> {
+        self.shifts
+            .iter()
+            .map(|&(col, amount)| ShiftSpec::new(col, amount))
+            .collect()
+    }
+
+    /// Index inside the down row's binary-polynomial slice of the virtual
+    /// column "`col` shifted down by `amount`".
+    fn down_idx(&self, col: usize, amount: usize) -> usize {
+        self.shifts
+            .binary_search(&(col, amount))
+            .expect("every (column, shift) pair used by a constraint is declared")
+    }
+}
+
+/// The memory-consistency UAIR for traces of `2^V` (padded) rows. See the
+/// module documentation for the full description of columns and
+/// constraints.
+///
+/// The trace-size exponent is a const generic because a
+/// [`UairSignature`] is static per type while the Beneš network's column
+/// count and row strides depend on the trace size; [`super::prover`]
+/// dispatches over the supported range.
 #[derive(Clone, Debug)]
-pub struct MemoryConsistencyUair;
+pub struct MemoryConsistencyUair<const V: usize>;
 
-impl Uair for MemoryConsistencyUair {
+impl<const V: usize> Uair for MemoryConsistencyUair<V> {
     type Ideal = DegreeOneIdeal<ZInt>;
     type FqIdeal = ImpossibleIdeal;
     type Scalar = DensePolynomial<ZInt, D>;
     type Prime = Fmod;
 
     fn signature() -> UairSignature<Self::Prime> {
-        let total = TotalColumnLayout::new(NUM_BP_COLS, 0, NUM_INT_COLS);
-        // Only `is_first` (the leading integer column) is public.
-        let public = PublicColumnLayout::new(0, 0, 1);
-        // Shift every address/time/value limb column and the instruction
-        // column down by one row, so constraints can compare adjacent rows.
-        // `source_col` uses flat `binary_poly || arbitrary_poly || int`
-        // indexing; the slack column `r` needs no shifted copy.
-        let mut shifts: Vec<ShiftSpec> = (BP_ADDR..BP_SLACK)
-            .map(|col| ShiftSpec::new(col, 1))
-            .collect();
-        shifts.push(ShiftSpec::new(NUM_BP_COLS + INT_INSTR, 1));
-        UairSignature::new(total, public, shifts, vec![])
+        let layout = NetLayout::new(V);
+        let total = TotalColumnLayout::new(layout.num_bp_cols, 0, layout.num_int_cols);
+        // `is_first` and the `upper_k` bit indicators (the leading integer
+        // columns) are public.
+        let public = PublicColumnLayout::new(0, 0, layout.num_public_int_cols);
+        UairSignature::new(total, public, layout.shift_specs(), vec![])
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR, IFqFromR>(
@@ -166,60 +383,60 @@ impl Uair for MemoryConsistencyUair {
         IFromR: Fn(&Self::Ideal) -> B::Ideal,
         IFqFromR: Fn(&Self::FqIdeal) -> B::FqIdeal,
     {
+        let layout = NetLayout::new(V);
         let one = from_ref(&DensePolynomial::new([1 as ZInt]));
         // Ideal (X - 2): membership means "the expression evaluates to zero
         // at X = 2", i.e. the base-2 recompositions of the involved binary
         // limbs satisfy the stated integer identity.
         let base2 = ideal_from_ref(&DegreeOneIdeal::new(2 as ZInt));
 
-        let is_first = &up.int[INT_IS_FIRST];
-        let instr = &up.int[INT_INSTR];
-        let selectors = &up.int[INT_S..INT_S + NUM_LEX_LIMBS];
-        let w = &up.int[INT_W];
-        let slack = &up.binary_poly[BP_SLACK];
-        let instr_next = &down.int[DOWN_INT_INSTR];
+        let is_first = &up.int[layout.int_is_first];
+        // Down-row accessor: the virtual column "`col` shifted by `amount`".
+        let down_bp = |col: usize, amount: usize| &down.binary_poly[layout.down_idx(col, amount)];
+
+        // ------------------------------------------------------------------
+        // Sorted trace (network state 0).
+        // ------------------------------------------------------------------
+        let instr_col = layout.state_col(0, PL_INSTR);
+        let instr = &up.binary_poly[instr_col];
+        let instr_next = down_bp(instr_col, 1);
+        let selectors = &up.int[layout.int_s..layout.int_s + NUM_LEX_LIMBS];
+        let w = &up.int[layout.int_w];
+        let slack_sorted = &up.binary_poly[layout.bp_slack_sorted];
 
         let instr_minus_one = instr.clone() - &one;
         let instr_next_minus_one = instr_next.clone() - &one;
 
-        // (1) The first access of the sorted trace must be a write:
-        //     is_first * (instr - 1) = 0.
-        // `is_first` is a *public* column whose `[1, 0, 0, ...]` pattern is
-        // checked directly by the verifier (`verify_memory_consistency`).
+        // (S1) The first access of the sorted trace must be a write:
+        //      is_first * (instr - 1) = 0.
         b.assert_zero(is_first.clone() * &instr_minus_one);
 
-        // (2) Instructions are boolean: instr' * (instr' - 1) = 0.
-        // Stated on the *next* row so it covers rows 1..2^num_vars-1; row 0
-        // is already pinned to a write by (1).
+        // (S2) Instructions are boolean (and, as polynomial cells, constant):
+        //      instr' * (instr' - 1) = 0. Stated on the *next* row so it
+        //      covers rows 1..2^V - 1; row 0 is pinned to a write by (S1).
         b.assert_zero(instr_next.clone() * &instr_next_minus_one);
 
-        // (3) Selector booleanity: s_j * (s_j - 1) = 0.
+        // (S3) Selector booleanity: s_j * (s_j - 1) = 0.
         for s_j in selectors {
             let s_j_minus_one = s_j.clone() - &one;
             b.assert_zero(s_j.clone() * &s_j_minus_one);
         }
 
-        // (4) Exactly one first-difference position: sum_j s_j = 1.
+        // (S4) Exactly one first-difference position: sum_j s_j = 1.
         let s_sum = selectors[1..]
             .iter()
             .fold(selectors[0].clone(), |acc, s_j| acc + s_j);
         b.assert_zero(s_sum - &one);
 
-        // (5) Limbs before the first difference are equal:
-        //     (1 - (s_0 + ... + s_j)) * (L'_j - L_j) = 0 for every lex limb j.
-        // (6) The first differing limb strictly increases:
-        //     sum_j s_j * (L'_j - L_j) - 1 - r  in  (X - 2).
-        // At X = 2 the latter reads d_k(2) = 1 + r(2) with r(2) a canonical
-        // u32, hence d_k(2) >= 1. The lexicographic limbs are the leading
-        // NUM_LEX_LIMBS binary columns; zipping with `selectors` (of exactly
-        // that length) walks them in order.
+        // (S5) Limbs before the first difference are equal:
+        //      (1 - (s_0 + ... + s_j)) * (L'_j - L_j) = 0 for every lex limb.
+        // (S6) The first differing limb strictly increases:
+        //      sum_j s_j * (L'_j - L_j) - 1 - r_S  in  (X - 2).
         let mut prefix: Option<B::Expr> = None;
         let mut increase: Option<B::Expr> = None;
-        for (s_j, (up_limb, down_limb)) in selectors
-            .iter()
-            .zip(up.binary_poly.iter().zip(down.binary_poly.iter()))
-        {
-            let d_j = down_limb.clone() - up_limb;
+        for (j, s_j) in selectors.iter().enumerate() {
+            let limb_col = layout.state_col(0, PL_ADDR + j);
+            let d_j = down_bp(limb_col, 1).clone() - &up.binary_poly[limb_col];
             let e_j = match prefix.take() {
                 None => s_j.clone(),
                 Some(sum) => sum + s_j,
@@ -233,41 +450,112 @@ impl Uair for MemoryConsistencyUair {
             });
         }
         let increase = increase.expect("NUM_LEX_LIMBS is non-zero");
-        b.assert_in_ideal(increase - &one - slack, &base2);
+        b.assert_in_ideal(increase - &one - slack_sorted, &base2);
 
         // `a_same` = 1 iff the first difference lies in the time limbs,
         // i.e. the adjacent rows touch the same address.
         let a_same = selectors[NUM_ADDR_LIMBS].clone() + &selectors[NUM_ADDR_LIMBS + 1];
 
-        // (7) Degree-reduction helper: w = a_same * (instr' - 1).
+        // (S7) Degree-reduction helper: w = a_same * (instr' - 1).
         let w_definition = a_same.clone() * &instr_next_minus_one;
         b.assert_zero(w.clone() - &w_definition);
 
-        // (8) A read at an unchanged address returns the previous value:
-        //     w * (value'_j - value_j) = 0 for every value limb j.
+        // (S8) A read at an unchanged address returns the previous value:
+        //      w * (value'_j - value_j) = 0 for every value limb j.
         for j in 0..NUM_VALUE_LIMBS {
-            let dv_j = down.binary_poly[BP_VALUE + j].clone() - &up.binary_poly[BP_VALUE + j];
+            let value_col = layout.state_col(0, PL_VALUE + j);
+            let dv_j = down_bp(value_col, 1).clone() - &up.binary_poly[value_col];
             b.assert_zero(w.clone() * &dv_j);
         }
 
-        // (9) The first access to a new address must be a write:
-        //     (1 - a_same) * (instr' - 1) = 0.
+        // (S9) The first access to a new address must be a write:
+        //      (1 - a_same) * (instr' - 1) = 0.
         let a_changed = one.clone() - &a_same;
         b.assert_zero(a_changed * &instr_next_minus_one);
+
+        // ------------------------------------------------------------------
+        // Original trace (the last network state): time_log starts at zero
+        // and strictly increases — the Halo2 `OriginalMemoryConfig` relation.
+        // ------------------------------------------------------------------
+        let time_hi_col = layout.state_col(layout.original_state(), PL_TIME);
+        let time_lo_col = layout.state_col(layout.original_state(), PL_TIME + 1);
+        let time_hi = &up.binary_poly[time_hi_col];
+        let time_lo = &up.binary_poly[time_lo_col];
+        let hi_sel = &up.int[layout.int_time_hi_sel];
+        let lo_sel = &up.int[layout.int_time_lo_sel];
+        let slack_original = &up.binary_poly[layout.bp_slack_original];
+
+        // (O1, O2) The first access happens at time_log = 0: both limbs of
+        // row 0 vanish.
+        b.assert_zero(is_first.clone() * time_hi);
+        b.assert_zero(is_first.clone() * time_lo);
+
+        // (O3) Selector booleanity and (O4) one-hotness.
+        let hi_sel_minus_one = hi_sel.clone() - &one;
+        b.assert_zero(hi_sel.clone() * &hi_sel_minus_one);
+        let lo_sel_minus_one = lo_sel.clone() - &one;
+        b.assert_zero(lo_sel.clone() * &lo_sel_minus_one);
+        b.assert_zero(hi_sel.clone() + lo_sel - &one);
+
+        // (O5) When the first difference is in the low limb, the high limbs
+        // are equal: (1 - o_hi) * (hi' - hi) = 0.
+        let d_hi = down_bp(time_hi_col, 1).clone() - time_hi;
+        let d_lo = down_bp(time_lo_col, 1).clone() - time_lo;
+        b.assert_zero((one.clone() - hi_sel) * &d_hi);
+
+        // (O6) The selected limb strictly increases:
+        //      o_hi*(hi' - hi) + o_lo*(lo' - lo) - 1 - r_O  in  (X - 2),
+        // which together with (O5) is exactly "the u64 time_log strictly
+        // increases".
+        let selected = hi_sel.clone() * &d_hi + &(lo_sel.clone() * &d_lo);
+        b.assert_in_ideal(selected - &one - slack_original, &base2);
+
+        // ------------------------------------------------------------------
+        // The Beneš network: state ℓ+1 is state ℓ with each switch pair
+        // conditionally swapped.
+        // ------------------------------------------------------------------
+        for layer in 0..layout.num_layers {
+            let stride = layout.stride(layer);
+            let mask = &up.int[layout.int_upper + benes::stride_bit(V, layer)];
+            let switch = &up.int[layout.int_switch + layer];
+
+            // (N1) Switch booleanity at every anchor (upper) row:
+            //      upper_k * s * (s - 1) = 0.
+            let switch_minus_one = switch.clone() - &one;
+            b.assert_zero(mask.clone() * &(switch.clone() * &switch_minus_one));
+
+            // (N2, N3) Conditional swap, cell-exact per payload column:
+            //      out₁ = in₁ + s·(in₂ - in₁),  out₂ = in₂ - s·(in₂ - in₁).
+            for payload in 0..PAYLOAD_CELLS {
+                let in_col = layout.state_col(layer, payload);
+                let out_col = layout.state_col(layer + 1, payload);
+                let in_1 = &up.binary_poly[in_col];
+                let in_2 = down_bp(in_col, stride);
+                let out_1 = &up.binary_poly[out_col];
+                let out_2 = down_bp(out_col, stride);
+                let diff = in_2.clone() - in_1;
+                let switched = switch.clone() * &diff;
+                b.assert_zero(mask.clone() * &(out_1.clone() - in_1 - &switched));
+                b.assert_zero(mask.clone() * &(out_2.clone() - in_2 + &switched));
+            }
+        }
     }
 }
 
-/// A sorted-trace row in 32-bit limb form (most-significant limb first).
+/// One trace record in 32-bit limb form (most-significant limb first): the
+/// payload routed through the permutation network.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct RowLimbs {
     /// Address limbs.
     addr: [u32; NUM_ADDR_LIMBS],
     /// `time_log` limbs.
     time: [u32; NUM_TIME_LIMBS],
+    /// `stack_depth` limbs.
+    stack_depth: [u32; NUM_STACK_DEPTH_LIMBS],
     /// Value limbs.
     value: [u32; NUM_VALUE_LIMBS],
     /// Instruction (`1` = write, `0` = read).
-    instr: ZInt,
+    instr: u32,
 }
 
 impl RowLimbs {
@@ -276,26 +564,36 @@ impl RowLimbs {
         let addr = be_bytes_to_limbs(&record.address().fixed_be_bytes());
         let value = be_bytes_to_limbs(&record.value().fixed_be_bytes());
         let time_log = record.time_log();
-        let time = [(time_log >> 32) as u32, time_log as u32];
+        let stack_depth = record.stack_depth();
         let instr = match record.instruction() {
             MemoryInstruction::Write => 1,
             MemoryInstruction::Read => 0,
         };
         Self {
             addr,
-            time,
+            time: [(time_log >> 32) as u32, time_log as u32],
+            stack_depth: [(stack_depth >> 32) as u32, stack_depth as u32],
             value,
             instr,
         }
     }
 
+    /// The payload cell `p` (see the module documentation's payload order).
+    fn payload(&self, p: usize) -> u32 {
+        match p {
+            PL_ADDR..PL_TIME => self.addr[p - PL_ADDR],
+            PL_TIME..PL_STACK_DEPTH => self.time[p - PL_TIME],
+            PL_STACK_DEPTH..PL_VALUE => self.stack_depth[p - PL_STACK_DEPTH],
+            PL_VALUE..PL_INSTR => self.value[p - PL_VALUE],
+            PL_INSTR => self.instr,
+            _ => unreachable!("payload index out of range"),
+        }
+    }
+
     /// The lexicographic comparison vector `address || time_log`.
     fn lex_limb(&self, j: usize) -> u32 {
-        if j < NUM_ADDR_LIMBS {
-            self.addr[j]
-        } else {
-            self.time[j - NUM_ADDR_LIMBS]
-        }
+        debug_assert!(j < NUM_LEX_LIMBS);
+        self.payload(PL_ADDR + j)
     }
 }
 
@@ -312,54 +610,81 @@ fn be_bytes_to_limbs(bytes: &[u8; 32]) -> [u32; 8] {
     })
 }
 
-/// Minimum trace size (`2^MIN_NUM_VARS` rows) accepted by the Zip+ codes.
-pub(crate) const MIN_NUM_VARS: usize = 3;
-/// Maximum trace size exponent accepted by [`build_uair_trace`] and by the
-/// verifier; bounds allocation on both sides.
-pub(crate) const MAX_NUM_VARS: usize = 24;
-
-/// Sort `trace` by `(address, time_log)` and build the full UAIR witness.
+/// Build the full UAIR witness for a *time-ordered* execution trace.
+///
+/// The input must satisfy the same contract the Halo2
+/// `OriginalMemoryCircuit` enforces on the original trace: `time_log`s
+/// start at `0` and strictly increase (gaps are allowed). The builder sorts
+/// the trace by `(address, time_log)`, pads both orderings with benign
+/// replay rows, routes the Beneš network linking them and assembles every
+/// witness column.
 ///
 /// Returns the witness trace together with the number of MLE variables
-/// (`log2` of the padded row count). The trace is padded to `2^num_vars`
-/// rows — with at least one padding row, so no real record ever occupies
-/// the final row, which Zinc+ exempts from constraints — by replaying the
-/// last record as reads with increasing `time_log`s, which keeps every
-/// constraint satisfied.
+/// (`log2` of the padded row count). At least one padding row is always
+/// kept, so no real record ever occupies the final row, which Zinc+
+/// exempts from constraints. Padding rows replay the last *sorted* record
+/// as reads with `time_log`s continuing past the global maximum, which
+/// satisfies both orderings' constraints and keeps the two padded
+/// multisets equal.
 ///
 /// # Errors
 ///
 /// * [`ZincMemoryError::EmptyTrace`] for an empty input,
-/// * [`ZincMemoryError::TraceTooLong`] for more than `2^MAX_NUM_VARS - 1` records,
-/// * [`ZincMemoryError::DuplicatedAccess`] when two records share an
-///   `(address, time_log)` pair (real machine traces have globally unique
-///   `time_log`s),
+/// * [`ZincMemoryError::FirstTimeNonZero`] when `time_log[0] != 0`,
+/// * [`ZincMemoryError::DuplicatedAccess`] when two consecutive records
+///   share a `time_log`,
+/// * [`ZincMemoryError::TimeNotIncreasing`] when a `time_log` decreases,
+/// * [`ZincMemoryError::TraceTooLong`] for more than `2^MAX_NUM_VARS - 1`
+///   records,
 /// * [`ZincMemoryError::TimeLogOverflow`] when the padding rows would
 ///   overflow the `u64` time domain.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_uair_trace(
     trace: &[TraceRecord<B256, B256, 32, 32>],
 ) -> Result<(UairTrace<'static, ZInt, ZInt, D, D>, usize), ZincMemoryError> {
+    // Halo2-parity input contract (`OriginalMemoryCircuit`): the trace is
+    // given in execution order, starting at time_log 0, strictly increasing.
+    if let Some(first) = trace.first() {
+        if first.time_log() != 0 {
+            return Err(ZincMemoryError::FirstTimeNonZero {
+                time_log: first.time_log(),
+            });
+        }
+    }
+    build_uair_trace_any_start(trace)
+}
+
+/// [`build_uair_trace`] without the `time_log[0] = 0` contract check.
+///
+/// The builder itself only needs strictly increasing `time_log`s; skipping
+/// the start check lets soundness tests hand the circuit an otherwise
+/// perfectly consistent witness whose *only* violation is the original
+/// trace not starting at time zero, isolating that in-circuit constraint.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_uair_trace_any_start(
+    trace: &[TraceRecord<B256, B256, 32, 32>],
+) -> Result<(UairTrace<'static, ZInt, ZInt, D, D>, usize), ZincMemoryError> {
     if trace.is_empty() {
         return Err(ZincMemoryError::EmptyTrace);
     }
-
-    let mut sorted = trace.to_vec();
-    sorted.sort_by(|a, b| match a.address().cmp(&b.address()) {
-        Ordering::Equal => a.time_log().cmp(&b.time_log()),
-        ordering => ordering,
-    });
-
-    for pair in sorted.windows(2) {
-        if pair[0].address() == pair[1].address() && pair[0].time_log() == pair[1].time_log() {
-            return Err(ZincMemoryError::DuplicatedAccess {
-                time_log: pair[0].time_log(),
-            });
+    for pair in trace.windows(2) {
+        match pair[1].time_log().cmp(&pair[0].time_log()) {
+            Ordering::Greater => {}
+            Ordering::Equal => {
+                return Err(ZincMemoryError::DuplicatedAccess {
+                    time_log: pair[0].time_log(),
+                })
+            }
+            Ordering::Less => {
+                return Err(ZincMemoryError::TimeNotIncreasing {
+                    time_log: pair[1].time_log(),
+                })
+            }
         }
     }
 
     // Reserve at least one padding row (the protocol-exempt last row).
-    let padded_len = sorted
+    let padded_len = trace
         .len()
         .checked_add(1)
         .and_then(usize::checked_next_power_of_two)
@@ -370,71 +695,147 @@ pub(crate) fn build_uair_trace(
     }
     let num_vars = num_vars.max(MIN_NUM_VARS);
     let num_rows = 1usize << num_vars;
+    let layout = NetLayout::new(num_vars);
 
-    // Limb-decompose the sorted records and append the padding rows: replay
-    // the last record as reads with strictly increasing time_logs.
-    let mut rows: Vec<RowLimbs> = sorted.iter().map(RowLimbs::from_record).collect();
-    let last = sorted.last().expect("trace is non-empty");
-    let mut padding_time = last.time_log();
-    for _ in rows.len()..num_rows {
+    let mut sorted = trace.to_vec();
+    sorted.sort_by(|a, b| match a.address().cmp(&b.address()) {
+        Ordering::Equal => a.time_log().cmp(&b.time_log()),
+        ordering => ordering,
+    });
+
+    // Padding rows replay the last sorted record (the maximum address) as
+    // reads with time_logs continuing past the global maximum, so they sit
+    // at the tail of *both* orderings and the two multisets stay equal.
+    let pad_base = *sorted.last().expect("trace is non-empty");
+    let mut padding = Vec::with_capacity(num_rows - trace.len());
+    let mut padding_time = trace.last().expect("trace is non-empty").time_log();
+    for _ in trace.len()..num_rows {
         padding_time = padding_time
             .checked_add(1)
             .ok_or(ZincMemoryError::TimeLogOverflow)?;
-        let mut padding = RowLimbs::from_record(last);
-        padding.time = [(padding_time >> 32) as u32, padding_time as u32];
-        padding.instr = 0;
-        rows.push(padding);
+        padding.push(TraceRecord::new(
+            padding_time,
+            pad_base.stack_depth(),
+            MemoryInstruction::Read,
+            pad_base.address(),
+            pad_base.value(),
+        ));
     }
 
-    // Per-transition witnesses: the one-hot first-difference selectors s_j,
-    // the lexicographic slack r and the degree-reduction helper w. The final
+    let original_rows: Vec<RowLimbs> = trace
+        .iter()
+        .chain(padding.iter())
+        .map(RowLimbs::from_record)
+        .collect();
+    let sorted_rows: Vec<RowLimbs> = sorted
+        .iter()
+        .chain(padding.iter())
+        .map(RowLimbs::from_record)
+        .collect();
+
+    // Sorted-trace transition witnesses: the one-hot first-difference
+    // selectors s_j, the lexicographic slack r_S and the helper w. The final
     // row has no successor and is exempted by the protocol; its transition
     // witnesses stay zero.
     let mut s_columns = vec![vec![0 as ZInt; num_rows]; NUM_LEX_LIMBS];
-    let mut slack_column = vec![BinaryPoly::<D>::from(0u32); num_rows];
+    let mut slack_sorted_column = vec![BinaryPoly::<D>::from(0u32); num_rows];
     let mut w_column = vec![0 as ZInt; num_rows];
     for i in 0..num_rows - 1 {
-        let (cur, next) = (&rows[i], &rows[i + 1]);
+        let (cur, next) = (&sorted_rows[i], &sorted_rows[i + 1]);
         let k = (0..NUM_LEX_LIMBS)
             .find(|&j| cur.lex_limb(j) != next.lex_limb(j))
-            // Unreachable: duplicates were rejected above and padding rows
-            // strictly increase the time limbs.
-            .ok_or(ZincMemoryError::DuplicatedAccess {
-                time_log: sorted.get(i).map_or(0, |r| r.time_log()),
-            })?;
+            // Unreachable: input time_logs are strictly increasing (hence
+            // globally unique) and padding rows extend them further.
+            .ok_or(ZincMemoryError::UnsortedTrace)?;
         let diff = i64::from(next.lex_limb(k)) - i64::from(cur.lex_limb(k));
         if diff < 1 {
-            // Unreachable: `rows` is sorted by exactly this limb order.
+            // Unreachable: `sorted_rows` is sorted by exactly this limb order.
             return Err(ZincMemoryError::UnsortedTrace);
         }
         s_columns[k][i] = 1;
-        slack_column[i] = BinaryPoly::from((diff - 1) as u32);
+        slack_sorted_column[i] = BinaryPoly::from((diff - 1) as u32);
         if k >= NUM_ADDR_LIMBS {
             // Same address: w = instr' - 1.
-            w_column[i] = rows[i + 1].instr - 1;
+            w_column[i] = ZInt::from(sorted_rows[i + 1].instr) - 1;
         }
     }
 
-    // Assemble the columns in the signature's flat order.
-    let mut binary_poly = Vec::with_capacity(NUM_BP_COLS);
-    for j in 0..NUM_ADDR_LIMBS {
-        binary_poly.push(bp_column(&rows, |row| row.addr[j]));
+    // Original-trace transition witnesses: which time limb first differs,
+    // and the slack of its strict increase.
+    let mut hi_sel_column = vec![0 as ZInt; num_rows];
+    let mut lo_sel_column = vec![0 as ZInt; num_rows];
+    let mut slack_original_column = vec![BinaryPoly::<D>::from(0u32); num_rows];
+    for i in 0..num_rows - 1 {
+        let (cur, next) = (&original_rows[i], &original_rows[i + 1]);
+        let (sel, diff) = if cur.time[0] != next.time[0] {
+            (
+                &mut hi_sel_column,
+                i64::from(next.time[0]) - i64::from(cur.time[0]),
+            )
+        } else {
+            (
+                &mut lo_sel_column,
+                i64::from(next.time[1]) - i64::from(cur.time[1]),
+            )
+        };
+        if diff < 1 {
+            // Unreachable: validated strictly increasing above.
+            return Err(ZincMemoryError::UnsortedTrace);
+        }
+        sel[i] = 1;
+        slack_original_column[i] = BinaryPoly::from((diff - 1) as u32);
     }
-    for j in 0..NUM_TIME_LIMBS {
-        binary_poly.push(bp_column(&rows, |row| row.time[j]));
-    }
-    for j in 0..NUM_VALUE_LIMBS {
-        binary_poly.push(bp_column(&rows, |row| row.value[j]));
-    }
-    binary_poly.push(slack_column.into_iter().collect());
 
-    let mut int = Vec::with_capacity(NUM_INT_COLS);
-    int.push(is_first_column(num_rows));
-    int.push(rows.iter().map(|row| row.instr).collect());
+    // The permutation linking the orderings: original row j holds the same
+    // record as sorted row perm[j]; time_logs are unique, so they key it.
+    let sorted_pos_by_time: BTreeMap<u64, usize> = sorted
+        .iter()
+        .chain(padding.iter())
+        .enumerate()
+        .map(|(pos, record)| (record.time_log(), pos))
+        .collect();
+    let perm: Vec<usize> = trace
+        .iter()
+        .chain(padding.iter())
+        .map(|record| sorted_pos_by_time[&record.time_log()])
+        .collect();
+
+    // Route the Beneš network and materialize every intermediate state's
+    // payload columns; state 0 is the sorted trace, the final state must be
+    // the original trace.
+    let switch_layers = benes::route(&perm);
+    let mut binary_poly = Vec::with_capacity(layout.num_bp_cols);
+    let mut state = sorted_rows.clone();
+    for layer in 0..=layout.num_layers {
+        if layer > 0 {
+            benes::apply_layer(&mut state, num_vars, layer - 1, &switch_layers[layer - 1]);
+        }
+        for payload in 0..PAYLOAD_CELLS {
+            binary_poly.push(bp_column(&state, |row| row.payload(payload)));
+        }
+    }
+    if state != original_rows {
+        // Unreachable: `benes::route` realizes exactly this permutation.
+        return Err(ZincMemoryError::UnsortedTrace);
+    }
+    binary_poly.push(slack_sorted_column.into_iter().collect());
+    binary_poly.push(slack_original_column.into_iter().collect());
+    debug_assert_eq!(binary_poly.len(), layout.num_bp_cols);
+
+    // Assemble the integer columns: publics first (exactly as the verifier
+    // rebuilds them), then the witness selectors and switch bits.
+    let mut int = Vec::with_capacity(layout.num_int_cols);
+    int.extend(public_int_columns(num_vars));
     for s_column in s_columns {
         int.push(s_column.into_iter().collect());
     }
     int.push(w_column.into_iter().collect());
+    int.push(hi_sel_column.into_iter().collect());
+    int.push(lo_sel_column.into_iter().collect());
+    for bits in &switch_layers {
+        int.push(bits.iter().map(|&bit| ZInt::from(bit)).collect());
+    }
+    debug_assert_eq!(int.len(), layout.num_int_cols);
 
     Ok((
         UairTrace {
@@ -454,7 +855,72 @@ fn bp_column(
     rows.iter().map(|row| BinaryPoly::from(limb(row))).collect()
 }
 
-/// The public `is_first` column: `[1, 0, 0, ...]`.
-pub(crate) fn is_first_column(num_rows: usize) -> zinc_poly::mle::DenseMultilinearExtension<ZInt> {
-    (0..num_rows).map(|i| ZInt::from(i == 0)).collect()
+/// The public integer columns, in signature order: `is_first`
+/// (`[1, 0, 0, ...]`) followed by the `upper_k` bit indicators
+/// (`upper_k[i] = 1` iff bit `k` of the row index `i` is zero), `k = 0 ..
+/// num_vars`. The verifier reconstructs these itself, so a proof is only
+/// accepted for exactly these public inputs.
+pub(crate) fn public_int_columns(
+    num_vars: usize,
+) -> Vec<zinc_poly::mle::DenseMultilinearExtension<ZInt>> {
+    let num_rows = 1usize << num_vars;
+    let mut columns = Vec::with_capacity(1 + num_vars);
+    columns.push((0..num_rows).map(|i| ZInt::from(i == 0)).collect());
+    for k in 0..num_vars {
+        columns.push((0..num_rows).map(|i| ZInt::from(i >> k & 1 == 0)).collect());
+    }
+    columns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_shift_list_is_sorted_and_complete() {
+        for num_vars in MIN_NUM_VARS..=6 {
+            let layout = NetLayout::new(num_vars);
+            assert!(layout.shifts.windows(2).all(|w| w[0] < w[1]));
+            // Every constraint-side lookup must resolve.
+            for layer in 0..layout.num_layers {
+                let stride = layout.stride(layer);
+                for payload in 0..PAYLOAD_CELLS {
+                    layout.down_idx(layout.state_col(layer, payload), stride);
+                    layout.down_idx(layout.state_col(layer + 1, payload), stride);
+                }
+            }
+            for j in 0..NUM_LEX_LIMBS {
+                layout.down_idx(layout.state_col(0, PL_ADDR + j), 1);
+            }
+            for j in 0..NUM_VALUE_LIMBS {
+                layout.down_idx(layout.state_col(0, PL_VALUE + j), 1);
+            }
+            layout.down_idx(layout.state_col(0, PL_INSTR), 1);
+            layout.down_idx(layout.state_col(layout.original_state(), PL_TIME), 1);
+            layout.down_idx(layout.state_col(layout.original_state(), PL_TIME + 1), 1);
+        }
+    }
+
+    #[test]
+    fn test_signature_dimensions_match_layout() {
+        let layout = NetLayout::new(3);
+        let signature = <MemoryConsistencyUair<3> as Uair>::signature();
+        assert_eq!(
+            signature.total_cols().num_binary_poly_cols(),
+            layout.num_bp_cols
+        );
+        assert_eq!(signature.total_cols().num_int_cols(), layout.num_int_cols);
+        assert_eq!(
+            signature.public_cols().num_int_cols(),
+            layout.num_public_int_cols
+        );
+        assert_eq!(signature.shifts().len(), layout.shifts.len());
+        // All shifted sources are binary columns, so the down row is pure
+        // binary: its layout must place every virtual column there.
+        assert_eq!(
+            signature.down_cols().num_binary_poly_cols(),
+            layout.shifts.len()
+        );
+        assert_eq!(signature.down_cols().num_int_cols(), 0);
+    }
 }


### PR DESCRIPTION
Closes #101

## What

Makes the Zinc+ backend prove **exactly the composed Halo2 `MemoryConsistencyCircuit` statement**, closing the two gaps left by the v1 integration (#98):

| sub-statement | Halo2 circuit | before | now |
|---|---|---|---|
| sorted-trace consistency | `SortedMemoryCircuit` | ✅ | ✅ (unchanged constraints) |
| original-trace time rules (`time[0] = 0`, strictly increasing) | `OriginalMemoryCircuit` | ❌ | ✅ one-hot limb selector + slack limb, exact `u64` semantics |
| sorted trace is a permutation of the original trace | `PermutationCircuit` (PLONK shuffle) | ❌ | ✅ deterministic Beneš switching network |

Both traces remain witnesses; like the Halo2 composed circuit there are no trace-dependent public inputs (the verifier reconstructs the fixed `is_first` and bit-indicator selector columns itself).

## Why a Beneš network instead of a shuffle argument

Randomized permutation arguments are **not expressible** in current Zinc+: no lookup layer (upstream scaffolding is explicitly unimplemented), no verifier-randomness (RAP-style) columns, and every committed cell is a small integer fixed *before* the random ~192-bit prime is Fiat-Shamir-sampled — a grand-product/LogUp accumulator over the proof field cannot even be materialized by the prover. Fixed-challenge/fixed-modulus workarounds are unsound (algebraic root-finding attacks).

The Beneš network is the established challenge-free RAM-checking technique (Pantry, Buffet, xJsnark) and fits Zinc+'s local-constraint model exactly:

- `2v − 1` layers of 2×2 conditional swaps between rows `i` and `i + 2^k`, expressed with static `ShiftSpec` row shifts and masked by public `upper_k` bit-indicator columns;
- one boolean switch witness per pair, shared by all 21 payload columns (address ‖ time ‖ stack_depth ‖ value ‖ instr), so records move atomically;
- swap equations are cell-exact (coefficient-wise, small coefficients ≪ q), so each state is *exactly* a permutation of the previous one: `multiset(O) = multiset(S)` holds with no probabilistic gap, and routing bits are completeness-only — a malicious router can only fail to prove.

Soundness details (incl. why Zinc+'s last-row exemption opens no hole: row `2^v − 1` has all index bits set and is never a switch anchor) are documented in `uair.rs`.

## Interface changes

- **Input contract now matches Halo2**: the trace must be in execution order with `time_log[0] = 0` and strictly increasing `time_log`s (gaps allowed) — previously any order was accepted and only the sorted view was proven. `machine.trace()` output satisfies this by construction. New errors: `FirstTimeNonZero`, `TimeNotIncreasing`; `DuplicatedAccess` now fires for any repeated `time_log` (Halo2's original circuit rejects those too).
- **`MAX_NUM_VARS` drops 24 → 16** (≤ 65 535 records): the verifier pays `O(2^{v−1})` field ops per large-stride shift predicate, so very large traces should wait for upstream's lookup layer (migration plan updated in the README).
- `MemoryConsistencyUair` is now const-generic over the trace-size exponent (a `UairSignature` is static per type while the network shape depends on trace size); prove/verify dispatch over `num_vars` 3..=16.

## Testing

- 127 tests pass with `--features zinc` (88 default-feature tests unaffected); fmt + clippy clean.
- New **witness-tampering soundness tests** corrupt exactly one cell of an honest witness — original-trace record, sorted-trace `stack_depth` limb, interior network state, switch bit (flip and non-boolean), time slack — and require rejection, plus an in-circuit check that a time-shifted (nonzero-start) but otherwise fully consistent witness is rejected by the circuit itself, not just input validation.
- Beneš routing has exhaustive/property tests (all 4-wire permutations, identities, reversals, rotations, random permutations up to 256 wires).
- Measured (release, commodity hw): 200 records → prove ~1.3 s, verify ~0.12 s, proof ~9 MiB; 900 records → ~6.4 s / ~0.2 s / ~11.5 MiB. The 5–8× proof-size growth vs. v1 is the price of the deterministic permutation argument and is documented.